### PR TITLE
Sync wisdom display with task state and plan insights dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,21 @@ The Journey Log is a web-based to-do list designed to help you track your tasks 
 6. Use the "Clear Completed Steps" button to remove all finished tasks.
 7. Select a theme from the "Choose a theme" dropdown to change the appearance of the application. Your theme preference will be saved.
 
-## Potential Future Enhancements
+## Recent Fixes
 
-* **Editing Tasks:** Allow users to modify existing tasks.
-* **Task Prioritization:** Add a way to mark tasks with different priority levels.
-* **More Themes:** Introduce additional visual themes.
-* **User Accounts (More Advanced):** Implement user accounts and data synchronization across devices (this would require backend development).
+* The wisdom panel now accurately reflects the state of your tasks on page load and after any action, so inspirational quotes stay in sync with completed steps.
+
+## Planned Enhancement: Journey Insights Dashboard
+
+To further motivate users, the next iteration will focus on a lightweight "Journey Insights" dashboard that surfaces progress at a glance.
+
+**Implementation plan:**
+
+1. **Data model updates:** Track completion timestamps and derive streaks and daily totals in `script.js`.
+2. **UI layout:** Add a summary section beneath the header in `index.html` that shows total steps, completed steps, and a progress bar.
+3. **Styling:** Extend `style.css` with cards and accent colors that adapt to existing themes without breaking readability.
+4. **Persistence & recalculation:** Ensure insights update whenever tasks are added, toggled, or cleared while persisting necessary metadata in local storage.
+5. **Accessibility:** Provide ARIA labels for new widgets and keep color contrast acceptable across all themes.
 
 ## Author
 

--- a/script.js
+++ b/script.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let tasks = loadTasks();
     renderTasks();
+    updateWisdomVisibility();
 
     const savedTheme = localStorage.getItem('journeyTheme');
         if (savedTheme) {
@@ -91,18 +92,14 @@ document.addEventListener('DOMContentLoaded', () => {
         );
         saveTasks();
         renderTasks();
-        if (tasks.find(task => task.id === taskId && task.completed)) {
-            showWisdom();
-        } else {
-            hideWisdom();
-        }
+        updateWisdomVisibility();
     }
 
     function deleteTask(taskId) {
         tasks = tasks.filter(task => task.id !== taskId);
         saveTasks();
         renderTasks();
-        hideWisdom(); // Hide wisdom if a completed task is deleted
+        updateWisdomVisibility();
     }
 
     function saveTasks() {
@@ -129,6 +126,15 @@ document.addEventListener('DOMContentLoaded', () => {
         tasks = tasks.filter(task => !task.completed);
         saveTasks();
         renderTasks();
-        hideWisdom(); // Hide wisdom if any was showing
+        updateWisdomVisibility();
+    }
+
+    function updateWisdomVisibility() {
+        const hasCompletedTasks = tasks.some(task => task.completed);
+        if (hasCompletedTasks) {
+            showWisdom();
+        } else {
+            hideWisdom();
+        }
     }
 });


### PR DESCRIPTION
## Summary
- ensure the wisdom panel reflects completed tasks on load and after any task updates
- document the recent fix and outline a Journey Insights dashboard plan in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b703e4930832f9ca704a7e8aa6c62)