### PR TITLE
Add journey insights summary section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,32 +13,47 @@ A simple and stylish to-do list application with a touch of wisdom, quick insigh
 The Journey Log is a web-based to-do list designed to help you track your tasks as "steps" in your personal journey. It allows you to:
 
 * **Add new steps:** Easily input and add tasks to your log.
+
 * **View your journey:** See a clear list of your current steps.
+
 * **Mark steps as complete:** Check off completed tasks, which will be visually marked with a strikethrough and optionally reveal an insightful quote.
+
 * **Delete steps:** Remove tasks from your log.
+
 * **Clear completed steps:** Quickly remove all finished tasks to keep your log tidy.
+
 * **See journey insights:** View totals, completed counts, active steps, and a progress indicator that updates automatically as you work.
+
 * **Customize the look:** Choose from different visual themes to personalize your Journey Log.
 
 ## Technologies Used
 
 * **HTML:** Provides the structural foundation of the application.
+
 * **CSS:** Handles the styling and visual presentation, including different themes.
+
 * **JavaScript:** Implements the interactive functionality, data management (using local storage), and theme switching.
 
 ## How to Use
 
 1. Clone this repository to your local machine.
+
 2. Open the `index.html` file in your web browser.
+
 3. Start adding your journey steps in the input field and click "Add Step" or press Enter.
+
 4. Check the checkbox next to a task to mark it as complete and potentially see a piece of wisdom.
+
 5. Click the "Delete" button next to a task to remove it.
+
 6. Use the "Clear Completed Steps" button to remove all finished tasks.
+
 7. Select a theme from the "Choose a theme" dropdown to change the appearance of the application. Your theme preference will be saved.
 
 ## Recent Improvements
 
 * The wisdom panel now accurately reflects the state of your tasks on page load and after any action, so inspirational quotes stay in sync with completed steps.
+
 * Added a Journey Insights row that surfaces total steps, completed and active counts, plus a live progress bar that updates whenever you change your list.
 
 ## Next Steps
@@ -52,3 +67,4 @@ WhatsYourWhy
 ## License
 
 MIT License
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository captures the evolution from an early LLM-generated prototype to 
 
 # The Journey Log
 
-A simple and stylish to-do list application with a touch of wisdom and customizable themes.
+A simple and stylish to-do list application with a touch of wisdom, quick insights, and customizable themes.
 
 ## Overview
 
@@ -17,6 +17,7 @@ The Journey Log is a web-based to-do list designed to help you track your tasks 
 * **Mark steps as complete:** Check off completed tasks, which will be visually marked with a strikethrough and optionally reveal an insightful quote.
 * **Delete steps:** Remove tasks from your log.
 * **Clear completed steps:** Quickly remove all finished tasks to keep your log tidy.
+* **See journey insights:** View totals, completed counts, active steps, and a progress indicator that updates automatically as you work.
 * **Customize the look:** Choose from different visual themes to personalize your Journey Log.
 
 ## Technologies Used
@@ -35,12 +36,14 @@ The Journey Log is a web-based to-do list designed to help you track your tasks 
 6. Use the "Clear Completed Steps" button to remove all finished tasks.
 7. Select a theme from the "Choose a theme" dropdown to change the appearance of the application. Your theme preference will be saved.
 
-## Potential Future Enhancements
+## Recent Improvements
 
-* **Editing Tasks:** Allow users to modify existing tasks.
-* **Task Prioritization:** Add a way to mark tasks with different priority levels.
-* **More Themes:** Introduce additional visual themes.
-* **User Accounts (More Advanced):** Implement user accounts and data synchronization across devices (this would require backend development).
+* The wisdom panel now accurately reflects the state of your tasks on page load and after any action, so inspirational quotes stay in sync with completed steps.
+* Added a Journey Insights row that surfaces total steps, completed and active counts, plus a live progress bar that updates whenever you change your list.
+
+## Next Steps
+
+Future iterations can build on these insights by tracking completion timestamps to show daily streaks and celebrating milestones.
 
 ## Author
 

--- a/index.html
+++ b/index.html
@@ -1,56 +1,111 @@
 <!DOCTYPE html>
+
 <html lang="en">
+
 <head>
+
     <meta charset="UTF-8">
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <title>The Journey Log</title>
+
     <link rel="stylesheet" href="style.css">
+
 </head>
+
 <body>
+
     <div class="container">
+
         <h1>The Journey Log</h1>
+
         <div class="theme-selector">
+
             <label for="theme">Choose a theme:</label>
+
             <select id="theme">
+
                 <option value="default">Default</option>
+
                 <option value="forest">Forest Trail</option>
+
                 <option value="ocean">Ocean Breeze</option>
+
                 <option value="dark">Midnight Sky</option>
+
             </select>
+
         </div>
+
         <section class="insights" aria-label="Journey insights">
+
             <div class="insight-card">
+
                 <p class="label">Total steps</p>
+
                 <p id="totalCount" class="value">0</p>
+
             </div>
+
             <div class="insight-card">
+
                 <p class="label">Completed</p>
+
                 <p id="completedCount" class="value">0</p>
+
             </div>
+
             <div class="insight-card">
+
                 <p class="label">Active</p>
+
                 <p id="activeCount" class="value">0</p>
+
             </div>
+
             <div class="insight-card progress-card">
+
                 <p class="label">Progress</p>
+
                 <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+
                     <div id="progressFill" class="progress-fill"></div>
+
                 </div>
+
                 <p id="progressPercent" class="value">0%</p>
+
             </div>
+
         </section>
+
         <div class="input-section">
+
             <input type="text" id="taskInput" placeholder="Add a new step in your journey...">
+
             <button id="addTaskButton">Add Step</button>
+
         </div>
+
         <button id="clearCompletedButton">Clear Completed Steps</button>
+
         <ul id="taskList">
+
         </ul>
+
         <div id="wisdomDisplay" class="hidden">
+
             <p><strong>Wisdom for this step:</strong></p>
+
             <p id="wisdomText"></p>
+
         </div>
+
     </div>
+
     <script src="script.js"></script>
+
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,27 @@
                 <option value="dark">Midnight Sky</option>
             </select>
         </div>
+        <section class="insights" aria-label="Journey insights">
+            <div class="insight-card">
+                <p class="label">Total steps</p>
+                <p id="totalCount" class="value">0</p>
+            </div>
+            <div class="insight-card">
+                <p class="label">Completed</p>
+                <p id="completedCount" class="value">0</p>
+            </div>
+            <div class="insight-card">
+                <p class="label">Active</p>
+                <p id="activeCount" class="value">0</p>
+            </div>
+            <div class="insight-card progress-card">
+                <p class="label">Progress</p>
+                <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div id="progressFill" class="progress-fill"></div>
+                </div>
+                <p id="progressPercent" class="value">0%</p>
+            </div>
+        </section>
         <div class="input-section">
             <input type="text" id="taskInput" placeholder="Add a new step in your journey...">
             <button id="addTaskButton">Add Step</button>

--- a/script.js
+++ b/script.js
@@ -10,15 +10,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const wisdomText = document.getElementById('wisdomText');
     const themeSelect = document.getElementById('theme');
     const bodyElement = document.body;
-
-    let tasks = loadTasks();
-    renderTasks();
-
-    const savedTheme = localStorage.getItem('journeyTheme');
-        if (savedTheme) {
-        themeSelect.value = savedTheme;
-        bodyElement.className = savedTheme === 'default' ? '' : `${savedTheme}-theme`;
-}
+    const totalCount = document.getElementById('totalCount');
+    const completedCount = document.getElementById('completedCount');
+    const activeCount = document.getElementById('activeCount');
+    const progressFill = document.getElementById('progressFill');
+    const progressPercent = document.getElementById('progressPercent');
 
     const wisdomQuotes = [
         "The journey of a thousand miles begins with a single step. - Lao Tzu",
@@ -27,6 +23,15 @@ document.addEventListener('DOMContentLoaded', () => {
         "Our greatest glory is not in never failing, but in rising up every time we fail. - Ralph Waldo Emerson",
         "The future belongs to those who believe in the beauty of their dreams. - Eleanor Roosevelt"
     ];
+
+    const savedTheme = localStorage.getItem('journeyTheme');
+    if (savedTheme) {
+        themeSelect.value = savedTheme;
+        bodyElement.className = savedTheme === 'default' ? '' : `${savedTheme}-theme`;
+    }
+
+    let tasks = loadTasks();
+    updateUI();
 
     themeSelect.addEventListener('change', (event) => {
         const selectedTheme = event.target.value;
@@ -56,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         tasks.push(task);
         saveTasks();
-        renderTasks();
+        updateUI();
     }
 
     function renderTasks() {
@@ -90,19 +95,13 @@ document.addEventListener('DOMContentLoaded', () => {
             task.id === taskId ? { ...task, completed: !task.completed } : task
         );
         saveTasks();
-        renderTasks();
-        if (tasks.find(task => task.id === taskId && task.completed)) {
-            showWisdom();
-        } else {
-            hideWisdom();
-        }
+        updateUI();
     }
 
     function deleteTask(taskId) {
         tasks = tasks.filter(task => task.id !== taskId);
         saveTasks();
-        renderTasks();
-        hideWisdom(); // Hide wisdom if a completed task is deleted
+        updateUI();
     }
 
     function saveTasks() {
@@ -128,7 +127,35 @@ document.addEventListener('DOMContentLoaded', () => {
     function clearCompletedTasks() {
         tasks = tasks.filter(task => !task.completed);
         saveTasks();
+        updateUI();
+    }
+
+    function updateWisdomVisibility() {
+        const hasCompletedTasks = tasks.some(task => task.completed);
+        if (hasCompletedTasks) {
+            showWisdom();
+        } else {
+            hideWisdom();
+        }
+    }
+
+    function updateInsights() {
+        const total = tasks.length;
+        const completed = tasks.filter(task => task.completed).length;
+        const active = total - completed;
+        const progress = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+        totalCount.textContent = total;
+        completedCount.textContent = completed;
+        activeCount.textContent = active;
+        progressFill.style.width = `${progress}%`;
+        progressFill.parentElement.setAttribute('aria-valuenow', progress);
+        progressPercent.textContent = `${progress}%`;
+    }
+
+    function updateUI() {
         renderTasks();
-        hideWisdom(); // Hide wisdom if any was showing
+        updateWisdomVisibility();
+        updateInsights();
     }
 });

--- a/script.js
+++ b/script.js
@@ -1,161 +1,321 @@
 console.log("JavaScript file loaded!");
 
+
+
 document.addEventListener('DOMContentLoaded', () => {
+
     const clearCompletedButton = document.getElementById('clearCompletedButton');
+
     clearCompletedButton.addEventListener('click', clearCompletedTasks);
+
     const taskInput = document.getElementById('taskInput');
+
     const addTaskButton = document.getElementById('addTaskButton');
+
     const taskList = document.getElementById('taskList');
+
     const wisdomDisplay = document.getElementById('wisdomDisplay');
+
     const wisdomText = document.getElementById('wisdomText');
+
     const themeSelect = document.getElementById('theme');
+
     const bodyElement = document.body;
+
     const totalCount = document.getElementById('totalCount');
+
     const completedCount = document.getElementById('completedCount');
+
     const activeCount = document.getElementById('activeCount');
+
     const progressFill = document.getElementById('progressFill');
+
     const progressPercent = document.getElementById('progressPercent');
 
+
+
     const wisdomQuotes = [
+
         "The journey of a thousand miles begins with a single step. - Lao Tzu",
+
         "The only way to do great work is to love what you do. - Steve Jobs",
+
         "Believe you can and you're halfway there. - Theodore Roosevelt",
+
         "Our greatest glory is not in never failing, but in rising up every time we fail. - Ralph Waldo Emerson",
+
         "The future belongs to those who believe in the beauty of their dreams. - Eleanor Roosevelt"
+
     ];
 
+
+
     const savedTheme = localStorage.getItem('journeyTheme');
+
     if (savedTheme) {
+
         themeSelect.value = savedTheme;
+
         bodyElement.className = savedTheme === 'default' ? '' : `${savedTheme}-theme`;
+
     }
+
+
 
     let tasks = loadTasks();
+
     updateUI();
 
+
+
     themeSelect.addEventListener('change', (event) => {
+
         const selectedTheme = event.target.value;
+
         bodyElement.className = selectedTheme === 'default' ? '' : `${selectedTheme}-theme`;
+
         localStorage.setItem('journeyTheme', selectedTheme); // Save the selected theme
+
     });
+
+
 
     addTaskButton.addEventListener('click', () => {
+
         const taskDescription = taskInput.value.trim();
+
         if (taskDescription) {
+
             addTask(taskDescription);
+
             taskInput.value = '';
+
         }
+
     });
+
+
 
     taskInput.addEventListener('keypress', (event) => {
+
         if (event.key === 'Enter') {
+
             addTaskButton.click();
+
         }
+
     });
 
+
+
     function addTask(description) {
+
         const task = {
+
             id: Date.now(),
+
             description: description,
+
             completed: false
+
         };
+
         tasks.push(task);
+
         saveTasks();
+
         updateUI();
+
     }
+
+
 
     function renderTasks() {
+
         taskList.innerHTML = '';
+
         tasks.forEach(task => {
+
             const listItem = document.createElement('li');
+
             const checkbox = document.createElement('input');
+
             checkbox.type = 'checkbox';
+
             checkbox.checked = task.completed;
+
             checkbox.addEventListener('change', () => toggleComplete(task.id));
 
+
+
             const taskSpan = document.createElement('span');
+
             taskSpan.textContent = task.description;
+
             if (task.completed) {
+
                 taskSpan.classList.add('completed');
+
             }
 
+
+
             const deleteButton = document.createElement('button');
+
             deleteButton.textContent = 'Delete';
+
             deleteButton.addEventListener('click', () => deleteTask(task.id));
 
+
+
             listItem.appendChild(checkbox);
+
             listItem.appendChild(taskSpan);
+
             listItem.appendChild(deleteButton);
+
             taskList.appendChild(listItem);
+
         });
+
     }
+
+
 
     function toggleComplete(taskId) {
+
         tasks = tasks.map(task =>
+
             task.id === taskId ? { ...task, completed: !task.completed } : task
+
         );
+
         saveTasks();
+
         updateUI();
+
     }
+
+
 
     function deleteTask(taskId) {
+
         tasks = tasks.filter(task => task.id !== taskId);
+
         saveTasks();
+
         updateUI();
+
     }
+
+
 
     function saveTasks() {
+
         localStorage.setItem('journeyTasks', JSON.stringify(tasks));
+
     }
+
+
 
     function loadTasks() {
+
         const storedTasks = localStorage.getItem('journeyTasks');
+
         return storedTasks ? JSON.parse(storedTasks) : [];
+
     }
+
+
 
     function showWisdom() {
+
         const randomIndex = Math.floor(Math.random() * wisdomQuotes.length);
+
         wisdomText.textContent = wisdomQuotes[randomIndex];
+
         wisdomDisplay.classList.remove('hidden');
+
     }
+
+
 
     function hideWisdom() {
+
         wisdomDisplay.classList.add('hidden');
+
         wisdomText.textContent = '';
+
     }
+
+
 
     function clearCompletedTasks() {
+
         tasks = tasks.filter(task => !task.completed);
+
         saveTasks();
+
         updateUI();
+
     }
+
+
 
     function updateWisdomVisibility() {
+
         const hasCompletedTasks = tasks.some(task => task.completed);
+
         if (hasCompletedTasks) {
+
             showWisdom();
+
         } else {
+
             hideWisdom();
+
         }
+
     }
+
+
 
     function updateInsights() {
+
         const total = tasks.length;
+
         const completed = tasks.filter(task => task.completed).length;
+
         const active = total - completed;
+
         const progress = total === 0 ? 0 : Math.round((completed / total) * 100);
 
+
+
         totalCount.textContent = total;
+
         completedCount.textContent = completed;
+
         activeCount.textContent = active;
+
         progressFill.style.width = `${progress}%`;
+
         progressFill.parentElement.setAttribute('aria-valuenow', progress);
+
         progressPercent.textContent = `${progress}%`;
+
     }
 
+
+
     function updateUI() {
+
         renderTasks();
+
         updateWisdomVisibility();
+
         updateInsights();
+
     }
+
 });

--- a/style.css
+++ b/style.css
@@ -20,6 +20,60 @@ h1 {
     margin-bottom: 20px;
 }
 
+.insights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 12px;
+    margin-bottom: 15px;
+}
+
+.insight-card {
+    background: linear-gradient(145deg, #ffffff, #f2f2f2);
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    padding: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.insight-card .label {
+    font-size: 13px;
+    color: #777;
+    margin: 0 0 6px;
+}
+
+.insight-card .value {
+    font-size: 20px;
+    font-weight: 700;
+    color: #333;
+    margin: 0;
+}
+
+.progress-card {
+    grid-column: span 2;
+}
+
+@media (max-width: 520px) {
+    .progress-card {
+        grid-column: span 1;
+    }
+}
+
+.progress-bar {
+    background: #ededed;
+    border-radius: 999px;
+    height: 10px;
+    width: 100%;
+    overflow: hidden;
+    margin-bottom: 6px;
+}
+
+.progress-fill {
+    background: linear-gradient(90deg, #5cb85c, #4cae4c);
+    height: 100%;
+    width: 0;
+    transition: width 0.2s ease;
+}
+
 .input-section {
     display: flex;
     margin-bottom: 15px;
@@ -139,6 +193,28 @@ body.forest-theme {
     color: #f1faee;
 }
 
+.forest-theme .insight-card {
+    background: linear-gradient(145deg, #4f8ab3, #3e6f8c);
+    border: 1px solid #1d3557;
+    box-shadow: none;
+}
+
+.forest-theme .insight-card .label {
+    color: #d9e6ef;
+}
+
+.forest-theme .insight-card .value {
+    color: #f1faee;
+}
+
+.forest-theme .progress-bar {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.forest-theme .progress-fill {
+    background: linear-gradient(90deg, #f1faee, #a8dadc);
+}
+
 .forest-theme h1 {
     color: #f1faee;
 }
@@ -197,6 +273,28 @@ body.ocean-theme {
     color: #01579b;
 }
 
+.ocean-theme .insight-card {
+    background: linear-gradient(145deg, #c5f2f7, #a5dbe4);
+    border: 1px solid #0277bd;
+    box-shadow: none;
+}
+
+.ocean-theme .insight-card .label {
+    color: #0277bd;
+}
+
+.ocean-theme .insight-card .value {
+    color: #01579b;
+}
+
+.ocean-theme .progress-bar {
+    background: rgba(1, 87, 155, 0.15);
+}
+
+.ocean-theme .progress-fill {
+    background: linear-gradient(90deg, #0277bd, #039be5);
+}
+
 .ocean-theme h1 {
     color: #01579b;
 }
@@ -253,6 +351,28 @@ body.dark-theme {
     background-color: #424242;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
     color: #e0e0e0;
+}
+
+.dark-theme .insight-card {
+    background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
+    border: 1px solid #616161;
+    box-shadow: none;
+}
+
+.dark-theme .insight-card .label {
+    color: #cccccc;
+}
+
+.dark-theme .insight-card .value {
+    color: #ffffff;
+}
+
+.dark-theme .progress-bar {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.dark-theme .progress-fill {
+    background: linear-gradient(90deg, #81c784, #66bb6a);
 }
 
 .dark-theme h1 {

--- a/style.css
+++ b/style.css
@@ -1,422 +1,843 @@
 body {
+
     font-family: sans-serif;
+
     margin: 20px;
+
     background-color: #f4f4f4;
+
     color: #333;
+
 }
+
+
 
 .container {
+
     max-width: 600px;
+
     margin: 0 auto;
+
     background-color: #fff;
+
     padding: 20px;
+
     border-radius: 8px;
+
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
 }
+
+
 
 h1 {
+
     text-align: center;
+
     color: #555;
+
     margin-bottom: 20px;
+
 }
+
+
 
 .insights {
+
     display: grid;
+
     grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+
     gap: 12px;
+
     margin-bottom: 15px;
+
 }
+
+
 
 .insight-card {
+
     background: linear-gradient(145deg, #ffffff, #f2f2f2);
+
     border: 1px solid #e5e5e5;
+
     border-radius: 8px;
+
     padding: 12px;
+
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
 }
+
+
 
 .insight-card .label {
+
     font-size: 13px;
+
     color: #777;
+
     margin: 0 0 6px;
+
 }
+
+
 
 .insight-card .value {
+
     font-size: 20px;
+
     font-weight: 700;
+
     color: #333;
+
     margin: 0;
+
 }
+
+
 
 .progress-card {
+
     grid-column: span 2;
+
 }
+
+
 
 @media (max-width: 520px) {
+
     .progress-card {
+
         grid-column: span 1;
+
     }
+
 }
+
+
 
 .progress-bar {
+
     background: #ededed;
+
     border-radius: 999px;
+
     height: 10px;
+
     width: 100%;
+
     overflow: hidden;
+
     margin-bottom: 6px;
+
 }
+
+
 
 .progress-fill {
+
     background: linear-gradient(90deg, #5cb85c, #4cae4c);
+
     height: 100%;
+
     width: 0;
+
     transition: width 0.2s ease;
+
 }
+
+
 
 .input-section {
+
     display: flex;
+
     margin-bottom: 15px;
+
 }
+
+
 
 #taskInput {
+
     flex-grow: 1;
+
     padding: 10px;
+
     border: 1px solid #ccc;
+
     border-radius: 4px 0 0 4px;
+
     font-size: 16px;
+
 }
+
+
 
 #addTaskButton {
+
     background-color: #5cb85c;
+
     color: white;
+
     border: none;
+
     padding: 10px 15px;
+
     border-radius: 0 4px 4px 0;
+
     cursor: pointer;
+
     font-size: 16px;
+
 }
+
+
 
 #addTaskButton:hover {
+
     background-color: #4cae4c;
+
 }
+
+
 
 #taskList {
+
     list-style-type: none;
+
     padding: 0;
+
 }
+
+
 
 #taskList li {
+
     padding: 10px;
+
     border-bottom: 1px solid #eee;
+
     display: flex;
+
     align-items: center;
+
     justify-content: space-between;
+
 }
+
+
 
 #taskList li:last-child {
+
     border-bottom: none;
+
 }
+
+
 
 #taskList li span {
+
     flex-grow: 1;
+
     margin-right: 10px;
+
 }
+
+
 
 #taskList li button {
+
     background-color: #d9534f;
+
     color: white;
+
     border: none;
+
     padding: 5px 10px;
+
     border-radius: 4px;
+
     cursor: pointer;
+
     font-size: 14px;
+
     margin-left: 5px;
+
 }
+
+
 
 #taskList li button:hover {
+
     background-color: #c9302c;
+
 }
+
+
 
 #taskList li input[type="checkbox"] {
+
     margin-right: 8px;
+
 }
+
+
 
 .hidden {
+
     display: none;
+
 }
+
+
 
 #wisdomDisplay {
+
     margin-top: 20px;
+
     padding: 15px;
+
     background-color: #f9f9f9;
+
     border: 1px solid #eee;
+
     border-radius: 4px;
+
     font-style: italic;
+
     color: #777;
+
 }
+
+
 
 #wisdomDisplay strong {
+
     font-style: normal;
+
     color: #555;
+
 }
+
 .completed {
+
     text-decoration: line-through;
+
     color: #888; 
+
 }
+
 /* Theme selector styles */
+
 .theme-selector {
+
     margin-bottom: 15px;
+
     display: flex;
+
     align-items: center;
+
 }
+
+
 
 .theme-selector label {
+
     margin-right: 10px;
+
 }
+
+
 
 .theme-selector select {
+
     padding: 8px;
+
     border-radius: 4px;
+
     border: 1px solid #ccc;
+
 }
+
+
 
 /* Forest Trail Theme */
+
 body.forest-theme {
+
     background-color: #a8dadc;
+
     color: #1d3557;
+
 }
+
+
 
 .forest-theme .container {
+
     background-color: #457b9d;
+
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+
     color: #f1faee;
+
 }
+
+
 
 .forest-theme .insight-card {
+
     background: linear-gradient(145deg, #4f8ab3, #3e6f8c);
+
     border: 1px solid #1d3557;
+
     box-shadow: none;
+
 }
+
+
 
 .forest-theme .insight-card .label {
+
     color: #d9e6ef;
+
 }
+
+
 
 .forest-theme .insight-card .value {
+
     color: #f1faee;
+
 }
+
+
 
 .forest-theme .progress-bar {
+
     background: rgba(255, 255, 255, 0.2);
+
 }
+
+
 
 .forest-theme .progress-fill {
+
     background: linear-gradient(90deg, #f1faee, #a8dadc);
+
 }
+
+
 
 .forest-theme h1 {
+
     color: #f1faee;
+
 }
+
+
 
 .forest-theme #addTaskButton {
+
     background-color: #1d3557;
+
     color: #f1faee;
+
 }
+
+
 
 .forest-theme #addTaskButton:hover {
+
     background-color: #0b132b;
+
 }
+
+
 
 .forest-theme #taskList li {
+
     border-bottom: 1px solid #a8dadc;
+
 }
+
+
 
 .forest-theme .completed {
+
     color: #a8dadc;
+
 }
+
+
 
 .forest-theme #clearCompletedButton {
+
     background-color: #1d3557;
+
     color: #f1faee;
+
     border: none;
+
     padding: 8px 12px;
+
     border-radius: 4px;
+
     cursor: pointer;
+
     font-size: 14px;
+
     margin-top: 10px;
+
 }
+
+
 
 .forest-theme #clearCompletedButton:hover {
+
     background-color: #0b132b;
+
 }
+
+
 
 .forest-theme #wisdomDisplay {
+
     background-color: #457b9d;
+
     border: 1px solid #1d3557;
+
     color: #f1faee;
+
 }
+
+
 
 .forest-theme #wisdomDisplay strong {
+
     color: #f1faee;
+
 }
+
+
 
 /* Ocean Breeze Theme */
+
 body.ocean-theme {
+
     background-color: #e0f2f7;
+
     color: #0277bd;
+
 }
+
+
 
 .ocean-theme .container {
+
     background-color: #b2ebf2;
+
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+
     color: #01579b;
+
 }
+
+
 
 .ocean-theme .insight-card {
+
     background: linear-gradient(145deg, #c5f2f7, #a5dbe4);
+
     border: 1px solid #0277bd;
+
     box-shadow: none;
+
 }
+
+
 
 .ocean-theme .insight-card .label {
+
     color: #0277bd;
+
 }
+
+
 
 .ocean-theme .insight-card .value {
+
     color: #01579b;
+
 }
+
+
 
 .ocean-theme .progress-bar {
+
     background: rgba(1, 87, 155, 0.15);
+
 }
+
+
 
 .ocean-theme .progress-fill {
+
     background: linear-gradient(90deg, #0277bd, #039be5);
+
 }
+
+
 
 .ocean-theme h1 {
+
     color: #01579b;
+
 }
+
+
 
 .ocean-theme #addTaskButton {
+
     background-color: #0277bd;
+
     color: #e0f2f7;
+
 }
+
+
 
 .ocean-theme #addTaskButton:hover {
+
     background-color: #01579b;
+
 }
+
+
 
 .ocean-theme #taskList li {
+
     border-bottom: 1px solid #e0f2f7;
+
 }
+
+
 
 .ocean-theme .completed {
+
     color: #80deea;
+
 }
+
+
 
 .ocean-theme #clearCompletedButton {
+
     background-color: #0277bd;
+
     color: #e0f2f7;
+
     border: none;
+
     padding: 8px 12px;
+
     border-radius: 4px;
+
     cursor: pointer;
+
     font-size: 14px;
+
     margin-top: 10px;
+
 }
+
+
 
 .ocean-theme #clearCompletedButton:hover {
+
     background-color: #01579b;
+
 }
+
+
 
 .ocean-theme #wisdomDisplay {
+
     background-color: #b2ebf2;
+
     border: 1px solid #0277bd;
+
     color: #01579b;
+
 }
+
+
 
 .ocean-theme #wisdomDisplay strong {
+
     color: #01579b;
+
 }
+
+
 
 /* Midnight Sky Theme */
+
 body.dark-theme {
+
     background-color: #212121;
+
     color: #f5f5f5;
+
 }
+
+
 
 .dark-theme .container {
+
     background-color: #424242;
+
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+
     color: #e0e0e0;
+
 }
+
+
 
 .dark-theme .insight-card {
+
     background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
+
     border: 1px solid #616161;
+
     box-shadow: none;
+
 }
+
+
 
 .dark-theme .insight-card .label {
+
     color: #cccccc;
+
 }
+
+
 
 .dark-theme .insight-card .value {
+
     color: #ffffff;
+
 }
+
+
 
 .dark-theme .progress-bar {
+
     background: rgba(255, 255, 255, 0.15);
+
 }
+
+
 
 .dark-theme .progress-fill {
+
     background: linear-gradient(90deg, #81c784, #66bb6a);
+
 }
+
+
 
 .dark-theme h1 {
+
     color: #e0e0e0;
+
 }
+
+
 
 .dark-theme #addTaskButton {
+
     background-color: #616161;
+
     color: #f5f5f5;
+
 }
+
+
 
 .dark-theme #addTaskButton:hover {
+
     background-color: #757575;
+
 }
+
+
 
 .dark-theme #taskList li {
+
     border-bottom: 1px solid #616161;
+
 }
+
+
 
 .dark-theme .completed {
+
     color: #9e9e9e;
+
 }
+
+
 
 .dark-theme #clearCompletedButton {
+
     background-color: #616161;
+
     color: #f5f5f5;
+
     border: none;
+
     padding: 8px 12px;
+
     border-radius: 4px;
+
     cursor: pointer;
+
     font-size: 14px;
+
     margin-top: 10px;
+
 }
+
+
 
 .dark-theme #clearCompletedButton:hover {
+
     background-color: #757575;
+
 }
+
+
 
 .dark-theme #wisdomDisplay {
+
     background-color: #424242;
+
     border: 1px solid #616161;
+
     color: #e0e0e0;
+
 }
 
+
+
 .dark-theme #wisdomDisplay strong {
+
     color: #e0e0e0;
+
 }


### PR DESCRIPTION
## Summary
- add a Journey Insights section with totals, completed/active counts, and a progress bar
- centralize UI refresh logic so insights and wisdom stay in sync with task changes
- style the new cards across all themes and document the feature in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b703e4930832f9ca704a7e8aa6c62)