### PR TITLE
Handle invalid stored tasks data

### DIFF
--- a/script.js
+++ b/script.js
@@ -114,7 +114,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function loadTasks() {
         const storedTasks = localStorage.getItem('journeyTasks');
-        return storedTasks ? JSON.parse(storedTasks) : [];
+        if (!storedTasks) {
+            return [];
+        }
+
+        try {
+            return JSON.parse(storedTasks);
+        } catch (error) {
+            console.warn('Failed to parse stored tasks, clearing corrupted data.', error);
+            localStorage.removeItem('journeyTasks');
+            return [];
+        }
     }
 
     function showWisdom() {


### PR DESCRIPTION
## Summary
- wrap task loading JSON parsing in a try/catch and default to an empty list on failure
- log a warning and clear corrupted journeyTasks data to prevent repeated parse errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694571b536a0832fa9046a1dfa5b9ddc)