### PR TITLE
Add Playwright coverage for journey insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "journey-log",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "journey-log",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.57.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "journey-log",
+  "version": "1.0.0",
+  "description": "This repository captures the evolution from an early LLM-generated prototype to the current workflow powered by OpenAI Codex. It shows how iterative prompts and code refinement can steadily improve a simple idea.",
+  "main": "script.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.57.0"
+  }
+}

--- a/tests/insights.spec.js
+++ b/tests/insights.spec.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Journey insights', () => {
+  test('reflect task state driven by updateInsights', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    const taskInput = page.locator('#taskInput');
+    const addTaskButton = page.getByRole('button', { name: 'Add Step' });
+    const progressFill = page.locator('#progressFill');
+    const progressBar = progressFill.locator('..');
+
+    const expectCounts = async (total, completed, active, progress) => {
+      await expect(page.locator('#totalCount')).toHaveText(String(total));
+      await expect(page.locator('#completedCount')).toHaveText(String(completed));
+      await expect(page.locator('#activeCount')).toHaveText(String(active));
+      await expect(page.locator('#progressPercent')).toHaveText(`${progress}%`);
+      await expect(progressBar).toHaveAttribute('aria-valuenow', String(progress));
+      const width = await progressFill.evaluate((node) => node.style.width);
+      expect(width).toBe(`${progress}%`);
+    };
+
+    const addTask = async (text) => {
+      await taskInput.fill(text);
+      await addTaskButton.click();
+    };
+
+    await addTask('Plan the route');
+    await addTask('Pack the bag');
+
+    await expectCounts(2, 0, 2, 0);
+
+    const firstCheckbox = page.locator('li', { hasText: 'Plan the route' }).locator('input[type="checkbox"]');
+    const secondCheckbox = page.locator('li', { hasText: 'Pack the bag' }).locator('input[type="checkbox"]');
+
+    await firstCheckbox.check();
+    await expectCounts(2, 1, 1, 50);
+
+    await secondCheckbox.check();
+    await expectCounts(2, 2, 0, 100);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright test that loads index.html, adds tasks, toggles completion, and asserts insight counts and progress updates
- introduce npm Playwright tooling and ignore generated artifacts

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457234e398832f85e401b6794ee927)