### PR TITLE
Improve accessibility and focus handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
                 <p class="label">Total steps</p>
 
-                <p id="totalCount" class="value">0</p>
+                <p id="totalCount" class="value" aria-live="polite" aria-atomic="true">0</p>
 
             </div>
 
@@ -52,7 +52,7 @@
 
                 <p class="label">Completed</p>
 
-                <p id="completedCount" class="value">0</p>
+                <p id="completedCount" class="value" aria-live="polite" aria-atomic="true">0</p>
 
             </div>
 
@@ -60,7 +60,7 @@
 
                 <p class="label">Active</p>
 
-                <p id="activeCount" class="value">0</p>
+                <p id="activeCount" class="value" aria-live="polite" aria-atomic="true">0</p>
 
             </div>
 
@@ -74,7 +74,7 @@
 
                 </div>
 
-                <p id="progressPercent" class="value">0%</p>
+                <p id="progressPercent" class="value" aria-live="polite" aria-atomic="true">0%</p>
 
             </div>
 
@@ -82,19 +82,19 @@
 
         <div class="input-section">
 
-            <input type="text" id="taskInput" placeholder="Add a new step in your journey...">
+            <input type="text" id="taskInput" placeholder="Add a new step in your journey..." aria-label="New journey step">
 
-            <button id="addTaskButton">Add Step</button>
+            <button id="addTaskButton" aria-label="Add a new journey step">Add Step</button>
 
         </div>
 
-        <button id="clearCompletedButton">Clear Completed Steps</button>
+        <button id="clearCompletedButton" aria-label="Clear all completed journey steps">Clear Completed Steps</button>
 
         <ul id="taskList">
 
         </ul>
 
-        <div id="wisdomDisplay" class="hidden">
+        <div id="wisdomDisplay" class="hidden" role="region" aria-live="polite" aria-expanded="false">
 
             <p><strong>Wisdom for this step:</strong></p>
 

--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ function updateInsights(tasks, elements) {
     const progressBar = progressFill.parentElement;
     if (progressBar && progressBar.setAttribute) {
         progressBar.setAttribute('aria-valuenow', progress.toString());
+        progressBar.setAttribute('aria-valuetext', `${progress}% complete`);
     }
 
     return { totalTasks, completedTasks, activeTasks, progress };
@@ -52,7 +53,6 @@ if (typeof document !== 'undefined') {
     const activeCount = document.getElementById('activeCount');
     const progressPercent = document.getElementById('progressPercent');
     const progressFill = document.getElementById('progressFill');
-
     let tasks = loadTasks();
     renderTasks();
     updateWisdomVisibility(tasks, showWisdom, hideWisdom);
@@ -82,6 +82,7 @@ if (typeof document !== 'undefined') {
         if (taskDescription) {
             addTask(taskDescription);
             taskInput.value = '';
+            taskInput.focus();
         }
     });
 
@@ -102,13 +103,43 @@ if (typeof document !== 'undefined') {
         renderTasks();
     }
 
-    function renderTasks() {
+    function captureFocusDetails(options = {}) {
+        const activeElement = document.activeElement;
+        const taskId = activeElement?.getAttribute?.('data-task-id') ?? null;
+        const control = activeElement?.getAttribute?.('data-control') ?? null;
+        const fallback = options.fallback ?? (typeof activeElement?.focus === 'function' ? activeElement : null);
+        return { taskId, control, fallback };
+    }
+
+    function restoreFocus(focusTarget) {
+        if (!focusTarget) {
+            return;
+        }
+
+        const { taskId, control, fallback } = focusTarget;
+        if (taskId && control) {
+            const selector = `[data-task-id="${taskId}"][data-control="${control}"]`;
+            const elementToFocus = taskList.querySelector(selector);
+            if (elementToFocus && typeof elementToFocus.focus === 'function') {
+                elementToFocus.focus();
+                return;
+            }
+        }
+
+        if (fallback && typeof fallback.focus === 'function') {
+            fallback.focus();
+        }
+    }
+
+    function renderTasks(focusTarget) {
         taskList.innerHTML = '';
         tasks.forEach(task => {
             const listItem = document.createElement('li');
             const checkbox = document.createElement('input');
             checkbox.type = 'checkbox';
             checkbox.checked = task.completed;
+            checkbox.dataset.taskId = task.id;
+            checkbox.dataset.control = 'checkbox';
             checkbox.addEventListener('change', () => toggleComplete(task.id));
 
             const taskSpan = document.createElement('span');
@@ -119,6 +150,9 @@ if (typeof document !== 'undefined') {
 
             const deleteButton = document.createElement('button');
             deleteButton.textContent = 'Delete';
+            deleteButton.dataset.taskId = task.id;
+            deleteButton.dataset.control = 'delete';
+            deleteButton.setAttribute('aria-label', `Delete ${task.description}`);
             deleteButton.addEventListener('click', () => deleteTask(task.id));
 
             listItem.appendChild(checkbox);
@@ -127,21 +161,24 @@ if (typeof document !== 'undefined') {
             taskList.appendChild(listItem);
         });
         updateInsights(tasks, { totalCount, completedCount, activeCount, progressPercent, progressFill });
+        restoreFocus(focusTarget);
     }
 
     function toggleComplete(taskId) {
+        const focusTarget = captureFocusDetails();
         tasks = tasks.map(task =>
             task.id === taskId ? { ...task, completed: !task.completed } : task
         );
         saveTasks();
-        renderTasks();
+        renderTasks(focusTarget);
         updateWisdomVisibility(tasks, showWisdom, hideWisdom);
     }
 
     function deleteTask(taskId) {
+        const focusTarget = captureFocusDetails({ fallback: taskInput });
         tasks = tasks.filter(task => task.id !== taskId);
         saveTasks();
-        renderTasks();
+        renderTasks(focusTarget);
         updateWisdomVisibility(tasks, showWisdom, hideWisdom);
     }
 
@@ -168,17 +205,20 @@ if (typeof document !== 'undefined') {
         const randomIndex = Math.floor(Math.random() * wisdomQuotes.length);
         wisdomText.textContent = wisdomQuotes[randomIndex];
         wisdomDisplay.classList.remove('hidden');
+        wisdomDisplay.setAttribute('aria-expanded', 'true');
     }
 
     function hideWisdom() {
         wisdomDisplay.classList.add('hidden');
         wisdomText.textContent = '';
+        wisdomDisplay.setAttribute('aria-expanded', 'false');
     }
 
     function clearCompletedTasks() {
+        const focusTarget = captureFocusDetails({ fallback: clearCompletedButton });
         tasks = tasks.filter(task => !task.completed);
         saveTasks();
-        renderTasks();
+        renderTasks(focusTarget);
         updateWisdomVisibility(tasks, showWisdom, hideWisdom);
     }
 

--- a/style.css
+++ b/style.css
@@ -10,6 +10,31 @@ body {
 
 }
 
+:focus-visible {
+    outline: 3px solid #2457cf;
+    outline-offset: 3px;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+#taskList li button:focus-visible {
+    box-shadow: 0 0 0 3px rgba(36, 87, 207, 0.15);
+}
+
+@media (prefers-contrast: more) {
+    :focus-visible {
+        outline-width: 4px;
+        outline-offset: 4px;
+    }
+
+    button:focus-visible,
+    input:focus-visible,
+    select:focus-visible {
+        box-shadow: 0 0 0 4px #fff;
+    }
+}
+
 
 
 .container {
@@ -386,6 +411,14 @@ body.forest-theme {
 
 }
 
+.forest-theme :focus-visible {
+
+    outline-color: #f1faee;
+
+    box-shadow: 0 0 0 3px rgba(241, 250, 238, 0.25);
+
+}
+
 
 
 .forest-theme .insight-card {
@@ -546,6 +579,14 @@ body.ocean-theme {
 
 }
 
+.ocean-theme :focus-visible {
+
+    outline-color: #01579b;
+
+    box-shadow: 0 0 0 3px rgba(1, 87, 155, 0.25);
+
+}
+
 
 
 .ocean-theme .insight-card {
@@ -703,6 +744,14 @@ body.dark-theme {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
 
     color: #e0e0e0;
+
+}
+
+.dark-theme :focus-visible {
+
+    outline-color: #b5d8ff;
+
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.25);
 
 }
 

--- a/tests/accessibility.spec.js
+++ b/tests/accessibility.spec.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Accessibility and focus management', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(indexFileUrl);
+  });
+
+  test('keeps focus stable when adding, toggling, and clearing tasks', async ({ page }) => {
+    const taskInput = page.locator('#taskInput');
+    const addTaskButton = page.getByRole('button', { name: /Add a new journey step/i });
+    const clearButton = page.getByRole('button', { name: /Clear all completed journey steps/i });
+
+    await taskInput.fill('First step');
+    await addTaskButton.click();
+    await expect(taskInput).toBeFocused();
+
+    await taskInput.fill('Second step');
+    await addTaskButton.click();
+
+    const firstCheckbox = page.locator('li').first().locator('input[type="checkbox"]');
+    await firstCheckbox.focus();
+    await firstCheckbox.check();
+    await expect(firstCheckbox).toBeFocused();
+
+    await clearButton.focus();
+    await clearButton.click();
+    await expect(clearButton).toBeFocused();
+  });
+
+  test('updates ARIA attributes when state changes', async ({ page }) => {
+    const totalCount = page.locator('#totalCount');
+    const completedCount = page.locator('#completedCount');
+    const activeCount = page.locator('#activeCount');
+    const progressBar = page.locator('.progress-bar');
+    const progressPercent = page.locator('#progressPercent');
+    const wisdomRegion = page.locator('#wisdomDisplay');
+    const taskInput = page.locator('#taskInput');
+    const addTaskButton = page.getByRole('button', { name: /Add a new journey step/i });
+
+    await expect(totalCount).toHaveAttribute('aria-live', 'polite');
+    await expect(completedCount).toHaveAttribute('aria-live', 'polite');
+    await expect(activeCount).toHaveAttribute('aria-live', 'polite');
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    await expect(progressPercent).toHaveText('0%');
+    await expect(wisdomRegion).toHaveAttribute('role', 'region');
+    await expect(wisdomRegion).toHaveAttribute('aria-expanded', 'false');
+
+    const addTask = async (text) => {
+      await taskInput.fill(text);
+      await addTaskButton.click();
+    };
+
+    await addTask('Pack the map');
+    await addTask('Lock the door');
+
+    const firstCheckbox = page.locator('li', { hasText: 'Pack the map' }).locator('input[type="checkbox"]');
+    const secondCheckbox = page.locator('li', { hasText: 'Lock the door' }).locator('input[type="checkbox"]');
+
+    await firstCheckbox.check();
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '50');
+    await expect(progressPercent).toHaveText('50%');
+    await expect(wisdomRegion).toHaveAttribute('aria-expanded', 'true');
+
+    await secondCheckbox.check();
+    await expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+    await expect(progressPercent).toHaveText('100%');
+  });
+});

--- a/tests/insights.spec.js
+++ b/tests/insights.spec.js
@@ -8,7 +8,7 @@ test.describe('Journey insights', () => {
     await page.goto(indexFileUrl);
 
     const taskInput = page.locator('#taskInput');
-    const addTaskButton = page.getByRole('button', { name: 'Add Step' });
+    const addTaskButton = page.getByRole('button', { name: /Add a new journey step/i });
     const progressFill = page.locator('#progressFill');
     const progressBar = progressFill.locator('..');
 


### PR DESCRIPTION
## Summary
- add aria-live announcements, descriptive labels, and a properly announced wisdom region
- stabilize focus after task interactions and keep progress bar ARIA values accurate
- refresh focus-visible styling across themes and add Playwright coverage for accessibility behaviors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457c4746b4832fba13422de8a92f43)