### PR TITLE
Add empty-state guidance for task list

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,11 @@
 
         <button id="clearCompletedButton">Clear Completed Steps</button>
 
+        <div id="emptyState" class="empty-state" aria-live="polite">
+            <p class="empty-state-title">No steps logged</p>
+            <p class="empty-state-message">Add your first step and press Enter.</p>
+        </div>
+
         <ul id="taskList">
 
         </ul>

--- a/script.js
+++ b/script.js
@@ -52,6 +52,7 @@ if (typeof document !== 'undefined') {
     const activeCount = document.getElementById('activeCount');
     const progressPercent = document.getElementById('progressPercent');
     const progressFill = document.getElementById('progressFill');
+    const emptyState = document.getElementById('emptyState');
 
     let tasks = loadTasks();
     renderTasks();
@@ -104,6 +105,7 @@ if (typeof document !== 'undefined') {
 
     function renderTasks() {
         taskList.innerHTML = '';
+        const taskCount = tasks.length;
         tasks.forEach(task => {
             const listItem = document.createElement('li');
             const checkbox = document.createElement('input');
@@ -127,6 +129,10 @@ if (typeof document !== 'undefined') {
             taskList.appendChild(listItem);
         });
         updateInsights(tasks, { totalCount, completedCount, activeCount, progressPercent, progressFill });
+        if (emptyState) {
+            const hasTasks = taskCount > 0;
+            emptyState.classList.toggle('hidden', hasTasks);
+        }
     }
 
     function toggleComplete(taskId) {

--- a/style.css
+++ b/style.css
@@ -212,6 +212,44 @@ h1 {
 
 }
 
+.empty-state {
+
+    margin: 12px 0 16px;
+
+    padding: 14px;
+
+    text-align: center;
+
+    background: linear-gradient(145deg, #ffffff, #f6f6f6);
+
+    border: 1px solid #e5e5e5;
+
+    border-radius: 8px;
+
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+    color: #555;
+
+}
+
+.empty-state-title {
+
+    margin: 0 0 6px;
+
+    font-weight: 700;
+
+    color: inherit;
+
+}
+
+.empty-state-message {
+
+    margin: 0;
+
+    color: #777;
+
+}
+
 
 
 #taskList li {
@@ -839,5 +877,55 @@ body.dark-theme {
 .dark-theme #wisdomDisplay strong {
 
     color: #e0e0e0;
+
+}
+
+/* Empty state theme adjustments */
+
+.forest-theme .empty-state {
+
+    background: linear-gradient(145deg, #4f8ab3, #3e6f8c);
+
+    border: 1px solid #1d3557;
+
+    color: #f1faee;
+
+}
+
+.forest-theme .empty-state-message {
+
+    color: #d9e6ef;
+
+}
+
+.ocean-theme .empty-state {
+
+    background: linear-gradient(145deg, #c5f2f7, #a5dbe4);
+
+    border: 1px solid #0277bd;
+
+    color: #01579b;
+
+}
+
+.ocean-theme .empty-state-message {
+
+    color: #0277bd;
+
+}
+
+.dark-theme .empty-state {
+
+    background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
+
+    border: 1px solid #616161;
+
+    color: #f5f5f5;
+
+}
+
+.dark-theme .empty-state-message {
+
+    color: #cccccc;
 
 }

--- a/tests/insights.spec.js
+++ b/tests/insights.spec.js
@@ -41,4 +41,25 @@ test.describe('Journey insights', () => {
     await secondCheckbox.check();
     await expectCounts(2, 2, 0, 100);
   });
+
+  test('empty state visibility tracks task count', async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    const taskInput = page.locator('#taskInput');
+    const addTaskButton = page.getByRole('button', { name: 'Add Step' });
+    const emptyState = page.locator('#emptyState');
+
+    await expect(emptyState).toBeVisible();
+
+    await taskInput.fill('Map the journey');
+    await addTaskButton.click();
+
+    await expect(emptyState).toBeHidden();
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+
+    await expect(emptyState).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- add an empty-state block to the task area with guidance for adding the first step
- toggle empty-state visibility in renderTasks and style it to match all themes
- extend Playwright coverage to verify the empty state shows and hides with task changes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457c314ed4832fb16081bb1685afca)