### PR TITLE
Add bulk task controls and keyboard shortcuts

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { updateInsights, updateWisdomVisibility } = require('../script.js');
+const { updateInsights, updateWisdomVisibility, toggleAllTasks, getSelectAllState } = require('../script.js');
 
 function createSpy() {
     const spy = (...args) => {
@@ -115,5 +115,37 @@ test.describe('updateWisdomVisibility', () => {
         expect(hasCompletedTasks).toBe(false);
         expect(hideWisdom.callCount()).toBe(1);
         expect(showWisdom.callCount()).toBe(0);
+    });
+});
+
+test.describe('bulk selection helpers', () => {
+    test('toggleAllTasks applies the desired completion state', () => {
+        const initialTasks = [
+            { id: 1, description: 'One', completed: false },
+            { id: 2, description: 'Two', completed: true }
+        ];
+
+        const allCompleted = toggleAllTasks(initialTasks, true);
+        expect(allCompleted.every(task => task.completed)).toBe(true);
+
+        const allActive = toggleAllTasks(initialTasks, false);
+        expect(allActive.every(task => task.completed)).toBe(false);
+    });
+
+    test('getSelectAllState reports checked and indeterminate correctly', () => {
+        const empty = getSelectAllState([]);
+        expect(empty).toEqual({ checked: false, indeterminate: false });
+
+        const mixed = getSelectAllState([
+            { id: 1, completed: true },
+            { id: 2, completed: false }
+        ]);
+        expect(mixed).toEqual({ checked: false, indeterminate: true });
+
+        const allDone = getSelectAllState([
+            { id: 1, completed: true },
+            { id: 2, completed: true }
+        ]);
+        expect(allDone).toEqual({ checked: true, indeterminate: false });
     });
 });

--- a/index.html
+++ b/index.html
@@ -88,7 +88,15 @@
 
         </div>
 
-        <button id="clearCompletedButton">Clear Completed Steps</button>
+        <div class="bulk-actions" role="toolbar" aria-label="Task selection controls">
+            <div class="bulk-toggle">
+                <label class="sr-only" for="selectAllCheckbox">Select all tasks</label>
+                <input type="checkbox" id="selectAllCheckbox" aria-label="Select all tasks">
+                <span aria-hidden="true" class="bulk-toggle-label">Select all</span>
+            </div>
+            <button id="clearSelectedButton" type="button">Clear selected</button>
+            <button id="clearCompletedButton" type="button">Clear Completed Steps</button>
+        </div>
 
         <ul id="taskList">
 

--- a/script.js
+++ b/script.js
@@ -37,12 +37,27 @@ function updateWisdomVisibility(tasks, showWisdom, hideWisdom) {
     return hasCompletedTasks;
 }
 
+function toggleAllTasks(tasks, shouldComplete) {
+    return tasks.map(task => ({ ...task, completed: shouldComplete }));
+}
+
+function getSelectAllState(tasks) {
+    const totalTasks = tasks.length;
+    const completedTasks = tasks.filter(task => task.completed).length;
+    return {
+        checked: totalTasks > 0 && completedTasks === totalTasks,
+        indeterminate: totalTasks > 0 && completedTasks > 0 && completedTasks < totalTasks
+    };
+}
+
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
     const clearCompletedButton = document.getElementById('clearCompletedButton');
+    const clearSelectedButton = document.getElementById('clearSelectedButton');
     const taskInput = document.getElementById('taskInput');
     const addTaskButton = document.getElementById('addTaskButton');
     const taskList = document.getElementById('taskList');
+    const selectAllCheckbox = document.getElementById('selectAllCheckbox');
     const wisdomDisplay = document.getElementById('wisdomDisplay');
     const wisdomText = document.getElementById('wisdomText');
     const themeSelect = document.getElementById('theme');
@@ -127,6 +142,7 @@ if (typeof document !== 'undefined') {
             taskList.appendChild(listItem);
         });
         updateInsights(tasks, { totalCount, completedCount, activeCount, progressPercent, progressFill });
+        syncSelectAllCheckbox();
     }
 
     function toggleComplete(taskId) {
@@ -182,7 +198,63 @@ if (typeof document !== 'undefined') {
         updateWisdomVisibility(tasks, showWisdom, hideWisdom);
     }
 
+    function clearSelectedTasks() {
+        clearCompletedTasks();
+    }
+
+    function syncSelectAllCheckbox() {
+        const { checked, indeterminate } = getSelectAllState(tasks);
+        selectAllCheckbox.checked = checked;
+        selectAllCheckbox.indeterminate = indeterminate;
+        selectAllCheckbox.disabled = tasks.length === 0;
+    }
+
+    function handleSelectAllChange(event) {
+        const shouldComplete = event.target.checked;
+        tasks = toggleAllTasks(tasks, shouldComplete);
+        saveTasks();
+        renderTasks();
+        updateWisdomVisibility(tasks, showWisdom, hideWisdom);
+    }
+
+    function isTypingInInput(element) {
+        if (!element) return false;
+        const tagName = element.tagName;
+        const interactiveTags = ['INPUT', 'TEXTAREA', 'SELECT'];
+        if (interactiveTags.includes(tagName)) {
+            return true;
+        }
+        return element.isContentEditable === true;
+    }
+
+    function handleKeyboardShortcuts(event) {
+        const isModifier = event.ctrlKey || event.metaKey;
+        if (!isModifier) return;
+
+        const activeElement = document.activeElement;
+        const typingInInput = isTypingInInput(activeElement);
+
+        if (event.key === 'Enter' && !event.shiftKey) {
+            if (activeElement === taskInput) {
+                event.preventDefault();
+                addTaskButton.click();
+            }
+            return;
+        }
+
+        if (event.key.toLowerCase() === 'c' && event.shiftKey) {
+            if (typingInInput && activeElement !== taskInput) {
+                return;
+            }
+            event.preventDefault();
+            clearCompletedTasks();
+        }
+    }
+
     clearCompletedButton.addEventListener('click', clearCompletedTasks);
+    clearSelectedButton.addEventListener('click', clearSelectedTasks);
+    selectAllCheckbox.addEventListener('change', handleSelectAllChange);
+    document.addEventListener('keydown', handleKeyboardShortcuts);
 });
 }
 
@@ -190,6 +262,8 @@ if (typeof module !== 'undefined') {
     module.exports = {
         computeInsights,
         updateInsights,
-        updateWisdomVisibility
+        updateWisdomVisibility,
+        toggleAllTasks,
+        getSelectAllState
     };
 }

--- a/style.css
+++ b/style.css
@@ -202,6 +202,101 @@ h1 {
 
 }
 
+.bulk-actions {
+
+    display: flex;
+
+    align-items: center;
+
+    gap: 10px;
+
+    margin-bottom: 15px;
+
+    padding: 10px 12px;
+
+    border: 1px solid #e5e5e5;
+
+    border-radius: 8px;
+
+    background-color: #fafafa;
+
+}
+
+.bulk-toggle {
+
+    display: flex;
+
+    align-items: center;
+
+    gap: 8px;
+
+}
+
+.bulk-toggle-label {
+
+    font-weight: 600;
+
+    color: #444;
+
+}
+
+.bulk-actions button {
+
+    background-color: #6c757d;
+
+    color: #fff;
+
+    border: none;
+
+    padding: 8px 12px;
+
+    border-radius: 6px;
+
+    cursor: pointer;
+
+    font-size: 14px;
+
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+
+}
+
+.bulk-actions button:hover {
+
+    background-color: #5a6268;
+
+}
+
+.bulk-actions button:focus-visible,
+.bulk-toggle input[type="checkbox"]:focus-visible {
+
+    outline: 3px solid #4cae4c;
+
+    outline-offset: 2px;
+
+    box-shadow: 0 0 0 4px rgba(76, 174, 76, 0.2);
+
+}
+
+.bulk-toggle input[type="checkbox"] {
+
+    width: 18px;
+
+    height: 18px;
+
+}
+
+#clearCompletedButton {
+
+    background-color: #5cb85c;
+
+}
+
+#clearCompletedButton:hover {
+
+    background-color: #4cae4c;
+
+}
+
 
 
 #taskList {
@@ -289,6 +384,30 @@ h1 {
 .hidden {
 
     display: none;
+
+}
+
+
+
+.sr-only {
+
+    position: absolute;
+
+    width: 1px;
+
+    height: 1px;
+
+    padding: 0;
+
+    margin: -1px;
+
+    overflow: hidden;
+
+    clip: rect(0, 0, 0, 0);
+
+    white-space: nowrap;
+
+    border: 0;
 
 }
 
@@ -427,6 +546,43 @@ body.forest-theme {
 .forest-theme .progress-fill {
 
     background: linear-gradient(90deg, #f1faee, #a8dadc);
+
+}
+
+.forest-theme .bulk-actions {
+
+    background-color: #3e6f8c;
+
+    border-color: #1d3557;
+
+}
+
+.forest-theme .bulk-toggle-label {
+
+    color: #f1faee;
+
+}
+
+.forest-theme .bulk-actions button {
+
+    background-color: #1d3557;
+
+    color: #f1faee;
+
+}
+
+.forest-theme .bulk-actions button:hover {
+
+    background-color: #0b132b;
+
+}
+
+.forest-theme .bulk-actions button:focus-visible,
+.forest-theme .bulk-toggle input[type="checkbox"]:focus-visible {
+
+    outline-color: #f1faee;
+
+    box-shadow: 0 0 0 4px rgba(241, 250, 238, 0.25);
 
 }
 
@@ -590,6 +746,43 @@ body.ocean-theme {
 
 }
 
+.ocean-theme .bulk-actions {
+
+    background-color: #c5f2f7;
+
+    border-color: #0277bd;
+
+}
+
+.ocean-theme .bulk-toggle-label {
+
+    color: #01579b;
+
+}
+
+.ocean-theme .bulk-actions button {
+
+    background-color: #0277bd;
+
+    color: #e0f2f7;
+
+}
+
+.ocean-theme .bulk-actions button:hover {
+
+    background-color: #01579b;
+
+}
+
+.ocean-theme .bulk-actions button:focus-visible,
+.ocean-theme .bulk-toggle input[type="checkbox"]:focus-visible {
+
+    outline-color: #0277bd;
+
+    box-shadow: 0 0 0 4px rgba(2, 119, 189, 0.2);
+
+}
+
 
 
 .ocean-theme h1 {
@@ -747,6 +940,43 @@ body.dark-theme {
 .dark-theme .progress-fill {
 
     background: linear-gradient(90deg, #81c784, #66bb6a);
+
+}
+
+.dark-theme .bulk-actions {
+
+    background-color: #333333;
+
+    border-color: #616161;
+
+}
+
+.dark-theme .bulk-toggle-label {
+
+    color: #e0e0e0;
+
+}
+
+.dark-theme .bulk-actions button {
+
+    background-color: #616161;
+
+    color: #f5f5f5;
+
+}
+
+.dark-theme .bulk-actions button:hover {
+
+    background-color: #757575;
+
+}
+
+.dark-theme .bulk-actions button:focus-visible,
+.dark-theme .bulk-toggle input[type="checkbox"]:focus-visible {
+
+    outline-color: #81c784;
+
+    box-shadow: 0 0 0 4px rgba(129, 199, 132, 0.25);
 
 }
 

--- a/tests/shortcuts.spec.js
+++ b/tests/shortcuts.spec.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Keyboard shortcuts', () => {
+  test('Ctrl/Cmd+Enter adds a task and Ctrl/Cmd+Shift+C clears completed', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    const taskInput = page.locator('#taskInput');
+    const taskListItems = page.locator('#taskList li');
+    const taskTextItems = page.locator('#taskList li span');
+
+    await taskInput.click();
+    await taskInput.fill('Shortcut add');
+    await page.keyboard.press('Control+Enter');
+
+    await expect(taskListItems).toHaveCount(1);
+    await expect(taskInput).toHaveValue('');
+
+    await taskInput.fill('Second task');
+    await page.keyboard.press('Control+Enter');
+    await expect(taskListItems).toHaveCount(2);
+
+    const firstCheckbox = page.locator('li', { hasText: 'Shortcut add' }).locator('input[type="checkbox"]');
+    await firstCheckbox.check();
+
+    await page.keyboard.press('Control+Shift+C');
+    await expect(taskListItems).toHaveCount(1);
+    await expect(taskTextItems).toHaveText(['Second task']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a bulk action toolbar with select-all and clear-selected controls plus accessible styling across themes
- implement bulk toggle logic, select-all state management, and keyboard shortcuts for adding and clearing tasks with appropriate guards
- expand unit coverage for the new helpers and add Playwright coverage for shortcut behaviors

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457c3d8694832f83ab581d5ece2f86)