### PR TITLE
Improve onboarding clarity and touch-friendly layout

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,12 +1,46 @@
+const { test, expect } = require('@playwright/test');
 const { updateInsights, updateWisdomVisibility } = require('../script.js');
 
+function createSpy() {
+    const spy = (...args) => {
+        spy.calls.push(args);
+    };
+    spy.calls = [];
+    spy.callCount = () => spy.calls.length;
+    return spy;
+}
+
 function createDomElements() {
-    const totalCount = document.createElement('span');
-    const completedCount = document.createElement('span');
-    const activeCount = document.createElement('span');
-    const progressPercent = document.createElement('span');
-    const progressBar = document.createElement('div');
-    const progressFill = document.createElement('div');
+    const createElement = () => {
+        let textContent = '';
+        return {
+            get textContent() {
+                return textContent;
+            },
+            set textContent(value) {
+                textContent = String(value);
+            },
+            style: {},
+            attributes: {},
+            parentElement: null,
+            appendChild(child) {
+                child.parentElement = this;
+            },
+            setAttribute(name, value) {
+                this.attributes[name] = value;
+            },
+            getAttribute(name) {
+                return this.attributes[name] ?? null;
+            }
+        };
+    };
+
+    const totalCount = createElement();
+    const completedCount = createElement();
+    const activeCount = createElement();
+    const progressPercent = createElement();
+    const progressBar = createElement();
+    const progressFill = createElement();
 
     progressBar.appendChild(progressFill);
 
@@ -19,7 +53,7 @@ function createDomElements() {
     };
 }
 
-describe('updateInsights', () => {
+test.describe('updateInsights', () => {
     test('handles zero tasks gracefully', () => {
         const elements = createDomElements();
         const tasks = [];
@@ -53,10 +87,10 @@ describe('updateInsights', () => {
     });
 });
 
-describe('updateWisdomVisibility', () => {
+test.describe('updateWisdomVisibility', () => {
     test('shows wisdom when there are completed tasks', () => {
-        const showWisdom = jest.fn();
-        const hideWisdom = jest.fn();
+        const showWisdom = createSpy();
+        const hideWisdom = createSpy();
         const tasks = [
             { id: 1, description: 'Done task', completed: true },
             { id: 2, description: 'Active task', completed: false }
@@ -65,13 +99,13 @@ describe('updateWisdomVisibility', () => {
         const hasCompletedTasks = updateWisdomVisibility(tasks, showWisdom, hideWisdom);
 
         expect(hasCompletedTasks).toBe(true);
-        expect(showWisdom).toHaveBeenCalledTimes(1);
-        expect(hideWisdom).not.toHaveBeenCalled();
+        expect(showWisdom.callCount()).toBe(1);
+        expect(hideWisdom.callCount()).toBe(0);
     });
 
     test('hides wisdom when there are no completed tasks', () => {
-        const showWisdom = jest.fn();
-        const hideWisdom = jest.fn();
+        const showWisdom = createSpy();
+        const hideWisdom = createSpy();
         const tasks = [
             { id: 1, description: 'Active task', completed: false }
         ];
@@ -79,7 +113,7 @@ describe('updateWisdomVisibility', () => {
         const hasCompletedTasks = updateWisdomVisibility(tasks, showWisdom, hideWisdom);
 
         expect(hasCompletedTasks).toBe(false);
-        expect(hideWisdom).toHaveBeenCalledTimes(1);
-        expect(showWisdom).not.toHaveBeenCalled();
+        expect(hideWisdom.callCount()).toBe(1);
+        expect(showWisdom.callCount()).toBe(0);
     });
 });

--- a/index.html
+++ b/index.html
@@ -90,6 +90,15 @@
 
         <button id="clearCompletedButton">Clear Completed Steps</button>
 
+        <div id="emptyState" class="empty-state hidden" aria-live="polite">
+            <p><strong>Start your journey:</strong> add a step and press Enter or click “Add Step”.</p>
+            <p>Your insights and wisdom will appear once you begin tracking steps.</p>
+        </div>
+
+        <div id="starterHint" class="starter-hint hidden" role="status" aria-live="polite">
+            <p><strong>Quick start:</strong> Type a step and press Enter. We’ll keep it saved.</p>
+        </div>
+
         <ul id="taskList">
 
         </ul>

--- a/script.js
+++ b/script.js
@@ -37,7 +37,8 @@ function updateWisdomVisibility(tasks, showWisdom, hideWisdom) {
     return hasCompletedTasks;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
     const clearCompletedButton = document.getElementById('clearCompletedButton');
     const taskInput = document.getElementById('taskInput');
     const addTaskButton = document.getElementById('addTaskButton');
@@ -51,10 +52,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const activeCount = document.getElementById('activeCount');
     const progressPercent = document.getElementById('progressPercent');
     const progressFill = document.getElementById('progressFill');
+    const emptyState = document.getElementById('emptyState');
+    const starterHint = document.getElementById('starterHint');
 
     let tasks = loadTasks();
     renderTasks();
     updateWisdomVisibility(tasks, showWisdom, hideWisdom);
+    if (taskInput && taskInput.focus) {
+        taskInput.focus();
+    }
 
     const savedTheme = localStorage.getItem('journeyTheme');
     if (savedTheme) {
@@ -103,6 +109,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function renderTasks() {
         taskList.innerHTML = '';
+        if (tasks.length === 0) {
+            emptyState.classList.remove('hidden');
+            starterHint.classList.remove('hidden');
+        } else {
+            emptyState.classList.add('hidden');
+            starterHint.classList.add('hidden');
+        }
         tasks.forEach(task => {
             const listItem = document.createElement('li');
             const checkbox = document.createElement('input');
@@ -183,6 +196,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     clearCompletedButton.addEventListener('click', clearCompletedTasks);
 });
+}
 
 if (typeof module !== 'undefined') {
     module.exports = {

--- a/style.css
+++ b/style.css
@@ -8,6 +8,8 @@ body {
 
     color: #333;
 
+    font-size: 17px;
+
 }
 
 
@@ -48,7 +50,7 @@ h1 {
 
     grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
 
-    gap: 12px;
+    gap: 14px;
 
     margin-bottom: 15px;
 
@@ -156,21 +158,25 @@ h1 {
 
     margin-bottom: 15px;
 
+    gap: 8px;
+
+    flex-wrap: wrap;
+
 }
 
 
 
 #taskInput {
 
-    flex-grow: 1;
+    flex: 1 1 200px;
 
-    padding: 10px;
+    padding: 12px;
 
     border: 1px solid #ccc;
 
-    border-radius: 4px 0 0 4px;
+    border-radius: 6px;
 
-    font-size: 16px;
+    font-size: 17px;
 
 }
 
@@ -184,13 +190,13 @@ h1 {
 
     border: none;
 
-    padding: 10px 15px;
+    padding: 12px 18px;
 
-    border-radius: 0 4px 4px 0;
+    border-radius: 0 6px 6px 0;
 
     cursor: pointer;
 
-    font-size: 16px;
+    font-size: 17px;
 
 }
 
@@ -209,6 +215,31 @@ h1 {
     list-style-type: none;
 
     padding: 0;
+
+}
+
+
+.empty-state {
+
+    background: linear-gradient(145deg, #ffffff, #f2f2f2);
+
+    border: 1px dashed #ccc;
+
+    border-radius: 8px;
+
+    padding: 12px 14px;
+
+    color: #666;
+
+    margin: 10px 0;
+
+    font-size: 16px;
+
+}
+
+.empty-state p {
+
+    margin: 4px 0;
 
 }
 
@@ -256,13 +287,13 @@ h1 {
 
     border: none;
 
-    padding: 5px 10px;
+    padding: 8px 12px;
 
-    border-radius: 4px;
+    border-radius: 6px;
 
     cursor: pointer;
 
-    font-size: 14px;
+    font-size: 15px;
 
     margin-left: 5px;
 
@@ -290,6 +321,21 @@ h1 {
 
     display: none;
 
+}
+
+#starterHint {
+    background: #fff8e1;
+    border: 1px solid #f0d78c;
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin: 10px 0 5px;
+    color: #7a5d00;
+    font-size: 16px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+#starterHint strong {
+    color: #5c4400;
 }
 
 

--- a/tests/insights.spec.js
+++ b/tests/insights.spec.js
@@ -11,6 +11,8 @@ test.describe('Journey insights', () => {
     const addTaskButton = page.getByRole('button', { name: 'Add Step' });
     const progressFill = page.locator('#progressFill');
     const progressBar = progressFill.locator('..');
+    const emptyState = page.locator('#emptyState');
+    const starterHint = page.locator('#starterHint');
 
     const expectCounts = async (total, completed, active, progress) => {
       await expect(page.locator('#totalCount')).toHaveText(String(total));
@@ -27,9 +29,17 @@ test.describe('Journey insights', () => {
       await addTaskButton.click();
     };
 
+    await expect(emptyState).toBeVisible();
+    await expect(starterHint).toBeVisible();
+    const activeElementId = await page.evaluate(() => document.activeElement?.id || '');
+    expect(activeElementId).toBe('taskInput');
+    await expectCounts(0, 0, 0, 0);
+
     await addTask('Plan the route');
     await addTask('Pack the bag');
 
+    await expect(emptyState).toBeHidden();
+    await expect(starterHint).toBeHidden();
     await expectCounts(2, 0, 2, 0);
 
     const firstCheckbox = page.locator('li', { hasText: 'Plan the route' }).locator('input[type="checkbox"]');


### PR DESCRIPTION
## Summary
- add a starter hint and input autofocus to guide first-time users immediately
- enlarge typography and button hit areas for better readability and touch usability
- keep onboarding helpers in sync with task counts via updated rendering logic and tests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457983f8e4832f9dcbaefc13bde514)