### PR TITLE
Add debounced save indicator and tests

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { updateInsights, updateWisdomVisibility } = require('../script.js');
+const { updateInsights, updateWisdomVisibility, createSaveFeedbackController } = require('../script.js');
 
 function createSpy() {
     const spy = (...args) => {
@@ -51,6 +51,49 @@ function createDomElements() {
         progressPercent,
         progressFill
     };
+}
+
+function createStatusElement() {
+    const classes = new Set();
+    return {
+        textContent: '',
+        attributes: {},
+        classList: {
+            add: (...tokens) => tokens.forEach(token => classes.add(token)),
+            remove: (...tokens) => tokens.forEach(token => classes.delete(token)),
+            has: (token) => classes.has(token)
+        },
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        },
+        getAttribute(name) {
+            return this.attributes[name] ?? null;
+        }
+    };
+}
+
+function createFakeScheduler() {
+    let tasks = [];
+    let lastId = 0;
+
+    const scheduler = (callback) => {
+        const id = ++lastId;
+        tasks.push({ id, callback });
+        return id;
+    };
+
+    const clearer = (id) => {
+        tasks = tasks.filter(task => task.id !== id);
+    };
+
+    const runNext = () => {
+        const nextTask = tasks.shift();
+        nextTask?.callback();
+    };
+
+    const pendingCount = () => tasks.length;
+
+    return { scheduler, clearer, runNext, pendingCount };
 }
 
 test.describe('updateInsights', () => {
@@ -115,5 +158,36 @@ test.describe('updateWisdomVisibility', () => {
         expect(hasCompletedTasks).toBe(false);
         expect(hideWisdom.callCount()).toBe(1);
         expect(showWisdom.callCount()).toBe(0);
+    });
+});
+
+test.describe('createSaveFeedbackController', () => {
+    test('debounces and hides the saved indicator after the display duration', () => {
+        const statusElement = createStatusElement();
+        const timers = createFakeScheduler();
+        const controller = createSaveFeedbackController(statusElement, {
+            scheduler: timers.scheduler,
+            clearer: timers.clearer,
+            displayDuration: 50,
+            showDelay: 5
+        });
+
+        controller.trigger();
+        controller.trigger();
+        expect(timers.pendingCount()).toBe(1);
+
+        timers.runNext(); // show
+        expect(statusElement.textContent).toBe('Saved');
+        expect(statusElement.classList.has('visible')).toBe(true);
+        expect(statusElement.getAttribute('aria-hidden')).toBe('false');
+
+        controller.trigger();
+        expect(timers.pendingCount()).toBe(1);
+
+        timers.runNext(); // show again, schedules hide
+        timers.runNext(); // hide
+        expect(statusElement.textContent).toBe('');
+        expect(statusElement.classList.has('visible')).toBe(false);
+        expect(statusElement.getAttribute('aria-hidden')).toBe('true');
     });
 });

--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
                 <div id="addHelperBubble" class="helper-bubble hidden" role="status" aria-live="polite" aria-hidden="true">
                     Tap Add after you type.
                 </div>
+                <div id="saveStatus" class="save-status" role="status" aria-live="polite" aria-hidden="true"></div>
             </div>
 
         </div>
@@ -114,11 +115,6 @@
             </div>
             <button id="clearSelectedButton" type="button">Clear selected</button>
             <button id="clearCompletedButton" type="button" aria-label="Clear all completed journey steps">Clear Completed Steps</button>
-        </div>
-
-        <div id="emptyState" class="empty-state hidden" aria-live="polite">
-            <p><strong>Start your journey:</strong> add a step and press Enter or click “Add Step”.</p>
-            <p>Your insights and wisdom will appear once you begin tracking steps.</p>
         </div>
 
         <div id="emptyState" class="empty-state hidden" aria-live="polite">

--- a/style.css
+++ b/style.css
@@ -131,6 +131,29 @@ h1 {
     position: relative;
 }
 
+.save-status {
+    font-size: 13px;
+    color: #1b5e20;
+    background-color: #eaf5ea;
+    border: 1px solid #c6e0c6;
+    border-radius: 999px;
+    padding: 6px 10px;
+    line-height: 1;
+    min-height: 26px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    font-weight: 700;
+}
+
+.save-status.visible {
+    visibility: visible;
+    opacity: 1;
+}
+
 #addTaskButton {
     background-color: #1b5e20;
     color: white;

--- a/tests/save-indicator.spec.js
+++ b/tests/save-indicator.spec.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Save indicator feedback', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('shows and clears the saved indicator after task changes', async ({ page }) => {
+    const taskInput = page.locator('#taskInput');
+    const addTaskButton = page.getByRole('button', { name: /Add Step/i });
+    const saveIndicator = page.locator('#saveStatus');
+
+    await expect(saveIndicator).toHaveAttribute('aria-hidden', 'true');
+
+    await taskInput.fill('Pack snacks');
+    await taskInput.press('Enter');
+
+    await expect(saveIndicator).toBeVisible();
+    await expect(saveIndicator).toHaveText(/Saved/i);
+    await expect(saveIndicator).toHaveAttribute('aria-hidden', 'false');
+    await expect(saveIndicator).toBeHidden({ timeout: 3000 });
+
+    const deleteButton = page.getByLabel(/Delete Pack snacks/i);
+    await deleteButton.click();
+
+    await expect(saveIndicator).toBeVisible();
+    await expect(saveIndicator).toHaveText(/Saved/i);
+    await expect(saveIndicator).toBeHidden({ timeout: 3000 });
+  });
+});


### PR DESCRIPTION
## Summary
- add a save status indicator near the input and style it for quick feedback
- debounce the save feedback controller, reuse storage writes, and export it for tests
- add unit and Playwright coverage for the save indicator timing and clean up duplicate empty state markup

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458ebe31f4832fae1653ad597a4848)