### PR TITLE
Improve theme accessibility and persistence

### DIFF
--- a/__tests__/theme-visual.test.js
+++ b/__tests__/theme-visual.test.js
@@ -1,0 +1,93 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const indexPath = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+function parseRgb(colorString) {
+    const [r = 0, g = 0, b = 0] = (colorString.match(/[\d.]+/g) || []).map(Number);
+    return { r, g, b };
+}
+
+function relativeLuminance({ r, g, b }) {
+    const toLinear = (value) => {
+        const channel = value / 255;
+        return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+    };
+
+    const [rl, gl, bl] = [toLinear(r), toLinear(g), toLinear(b)];
+    return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrastRatio(foreground, background) {
+    const fg = parseRgb(foreground);
+    const bg = parseRgb(background);
+    const l1 = relativeLuminance(fg);
+    const l2 = relativeLuminance(bg);
+    const lighter = Math.max(l1, l2);
+    const darker = Math.min(l1, l2);
+    return (lighter + 0.05) / (darker + 0.05);
+}
+
+test.describe('theme accessibility', () => {
+    test('default theme maintains AA contrast for body text and primary button', async ({ page }) => {
+        await page.goto(indexPath);
+
+        const bodyColors = await page.$eval('body', (el) => {
+            const styles = getComputedStyle(el);
+            return { text: styles.color, background: styles.backgroundColor };
+        });
+        expect(contrastRatio(bodyColors.text, bodyColors.background)).toBeGreaterThanOrEqual(4.5);
+
+        const addButtonColors = await page.$eval('#addTaskButton', (el) => {
+            const styles = getComputedStyle(el);
+            return { text: styles.color, background: styles.backgroundColor };
+        });
+        expect(contrastRatio(addButtonColors.text, addButtonColors.background)).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test('theme selection persists through localStorage and reload', async ({ page }) => {
+        await page.goto(indexPath);
+        await page.selectOption('#theme', 'high-contrast');
+
+        const storedTheme = await page.evaluate(() => localStorage.getItem('journeyTheme'));
+        expect(storedTheme).toBe('high-contrast');
+
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        const selectedTheme = await page.$eval('#theme', (el) => el.value);
+        expect(selectedTheme).toBe('high-contrast');
+    });
+
+    test('high contrast theme increases button contrast', async ({ page }) => {
+        await page.goto(indexPath);
+        await page.selectOption('#theme', 'high-contrast');
+
+        await page.waitForFunction(
+            () => {
+                const el = document.querySelector('#addTaskButton');
+                if (!el) return false;
+                const styles = getComputedStyle(el);
+                const text = styles.color;
+                const background = styles.backgroundColor;
+                const parseRgb = (colorString) => {
+                    const [r = 0, g = 0, b = 0] = (colorString.match(/[\d.]+/g) || []).map(Number);
+                    return { r, g, b };
+                };
+                const relativeLuminance = ({ r, g, b }) => {
+                    const toLinear = (value) => {
+                        const channel = value / 255;
+                        return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+                    };
+                    const [rl, gl, bl] = [toLinear(r), toLinear(g), toLinear(b)];
+                    return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+                };
+                const fg = parseRgb(text);
+                const bg = parseRgb(background);
+                const lighter = Math.max(relativeLuminance(fg), relativeLuminance(bg));
+                const darker = Math.min(relativeLuminance(fg), relativeLuminance(bg));
+                const ratio = (lighter + 0.05) / (darker + 0.05);
+                return ratio >= 7;
+            },
+            { timeout: 2000 }
+        );
+    });
+});

--- a/index.html
+++ b/index.html
@@ -34,21 +34,14 @@
         </section>
 
         <div class="theme-selector">
-
-            <label for="theme">Choose a theme:</label>
-
+            <label for="theme">Theme</label>
             <select id="theme">
-
-                <option value="default">Default</option>
-
-                <option value="forest">Forest Trail</option>
-
-                <option value="ocean">Ocean Breeze</option>
-
-                <option value="dark">Midnight Sky</option>
-
+                <option value="comfort" selected>Comfort</option>
+                <option value="forest">Forest</option>
+                <option value="ocean">Ocean</option>
+                <option value="dark">Midnight</option>
+                <option value="high-contrast">High contrast</option>
             </select>
-
         </div>
 
         <section class="insights" aria-label="Journey insights">
@@ -114,11 +107,6 @@
             </div>
             <button id="clearSelectedButton" type="button">Clear selected</button>
             <button id="clearCompletedButton" type="button" aria-label="Clear all completed journey steps">Clear Completed Steps</button>
-        </div>
-
-        <div id="emptyState" class="empty-state hidden" aria-live="polite">
-            <p><strong>Start your journey:</strong> add a step and press Enter or click “Add Step”.</p>
-            <p>Your insights and wisdom will appear once you begin tracking steps.</p>
         </div>
 
         <div id="emptyState" class="empty-state hidden" aria-live="polite">

--- a/script.js
+++ b/script.js
@@ -66,6 +66,7 @@ if (typeof document !== 'undefined') {
     const selectAllCheckbox = document.getElementById('selectAllCheckbox');
     const wisdomDisplay = document.getElementById('wisdomDisplay');
     const wisdomText = document.getElementById('wisdomText');
+    const starterHint = document.getElementById('starterHint');
     const themeSelect = document.getElementById('theme');
     const bodyElement = document.body;
     const totalCount = document.getElementById('totalCount');
@@ -75,6 +76,9 @@ if (typeof document !== 'undefined') {
     const progressFill = document.getElementById('progressFill');
     const emptyState = document.getElementById('emptyState');
     const helperBubbleKey = 'journeySeenAddHelper';
+    const supportedThemes = ['comfort', 'forest', 'ocean', 'dark', 'high-contrast'];
+    const themeClasses = supportedThemes.map(theme => `${theme}-theme`);
+    const defaultTheme = 'comfort';
 
     let tasks = loadTasks();
     initializeHelperBubble();
@@ -84,11 +88,7 @@ if (typeof document !== 'undefined') {
         taskInput.focus();
     }
 
-    const savedTheme = localStorage.getItem('journeyTheme');
-    if (savedTheme) {
-        themeSelect.value = savedTheme;
-        bodyElement.className = savedTheme === 'default' ? '' : `${savedTheme}-theme`;
-    }
+    applyTheme(localStorage.getItem('journeyTheme'));
 
     const wisdomQuotes = [
         "The journey of a thousand miles begins with a single step. - Lao Tzu",
@@ -100,11 +100,7 @@ if (typeof document !== 'undefined') {
 
     taskInput?.focus();
 
-    themeSelect.addEventListener('change', (event) => {
-        const selectedTheme = event.target.value;
-        bodyElement.className = selectedTheme === 'default' ? '' : `${selectedTheme}-theme`;
-        localStorage.setItem('journeyTheme', selectedTheme); // Save the selected theme
-    });
+    themeSelect.addEventListener('change', (event) => applyTheme(event.target.value));
 
     addTaskButton.addEventListener('click', () => {
         const taskDescription = taskInput.value.trim();
@@ -360,6 +356,45 @@ if (typeof document !== 'undefined') {
 
     function dismissHelperBubble() {
         hideHelperBubble(true);
+    }
+
+    function normalizeTheme(theme) {
+        if (theme === 'default') {
+            return defaultTheme;
+        }
+        return supportedThemes.includes(theme) ? theme : defaultTheme;
+    }
+
+    function applyTheme(themeValue) {
+        const normalizedTheme = normalizeTheme(themeValue);
+        document.documentElement.classList.remove(...themeClasses);
+        document.documentElement.classList.add(`${normalizedTheme}-theme`);
+        bodyElement.classList.remove(...themeClasses);
+        bodyElement.classList.add(`${normalizedTheme}-theme`);
+        document.documentElement.dataset.theme = normalizedTheme;
+        bodyElement.dataset.theme = normalizedTheme;
+        if (normalizedTheme === 'high-contrast') {
+            if (addTaskButton) {
+                addTaskButton.style.cssText = [
+                    'background: #ffd60a !important',
+                    'background-color: #ffd60a !important',
+                    'color: #0d0d0d !important',
+                    'border-color: #ffb700 !important'
+                ].join('; ');
+            }
+            bodyElement.style.setProperty('background-color', '#000000', 'important');
+            bodyElement.style.setProperty('color', '#ffffff', 'important');
+        } else {
+            if (addTaskButton) {
+                addTaskButton.style.cssText = '';
+            }
+            bodyElement.style.removeProperty('background-color');
+            bodyElement.style.removeProperty('color');
+        }
+        if (themeSelect.value !== normalizedTheme) {
+            themeSelect.value = normalizedTheme;
+        }
+        localStorage.setItem('journeyTheme', normalizedTheme);
     }
 });
 }

--- a/style.css
+++ b/style.css
@@ -1,21 +1,269 @@
+:root {
+    --font-family: "Inter", system-ui, -apple-system, sans-serif;
+    --base-font-size: 18px;
+    --page-bg: #f5f7fb;
+    --surface-color: #ffffff;
+    --panel-color: #e8eef9;
+    --border-color: #d9e1ec;
+    --text-color: #1d2741;
+    --muted-text: #4b5672;
+    --completed-text: #6b758c;
+    --accent-color: #1c3a8a;
+    --accent-strong: #15316f;
+    --action-color: #1c3a8a;
+    --action-hover: #15316f;
+    --button-text: #ffffff;
+    --neutral-button: #596273;
+    --neutral-hover: #4d5667;
+    --neutral-text: #ffffff;
+    --success-color: #2f855a;
+    --success-strong: #266b49;
+    --danger-color: #c1322f;
+    --danger-hover: #a52724;
+    --input-border: #c6cedd;
+    --shadow-soft: 0 10px 24px rgba(24, 39, 75, 0.12);
+    --card-shadow: 0 1px 3px rgba(24, 39, 75, 0.12);
+    --focus-ring-shadow: rgba(36, 87, 207, 0.22);
+    --progress-start: #3ea76a;
+    --progress-end: #2f855a;
+}
+
 body {
-    font-family: sans-serif;
-    font-size: 17px;
+    font-family: var(--font-family);
+    font-size: var(--base-font-size);
     line-height: 1.6;
-    margin: 20px;
-    background-color: #f4f4f4;
-    color: #333;
+    margin: 0;
+    padding: 24px;
+    background-color: var(--page-bg);
+    color: var(--text-color);
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-    font-size: 17px;
-
+body.comfort-theme {
+    --page-bg: #f5f7fb;
+    --surface-color: #ffffff;
+    --panel-color: #e8eef9;
+    --border-color: #d9e1ec;
+    --text-color: #1d2741;
+    --muted-text: #4b5672;
+    --completed-text: #6b758c;
+    --accent-color: #1c3a8a;
+    --accent-strong: #15316f;
+    --action-color: #1c3a8a;
+    --action-hover: #15316f;
+    --button-text: #ffffff;
+    --neutral-button: #596273;
+    --neutral-hover: #4d5667;
+    --neutral-text: #ffffff;
+    --success-color: #2f855a;
+    --success-strong: #266b49;
+    --danger-color: #c1322f;
+    --danger-hover: #a52724;
+    --input-border: #c6cedd;
+    --shadow-soft: 0 10px 24px rgba(24, 39, 75, 0.12);
+    --card-shadow: 0 1px 3px rgba(24, 39, 75, 0.12);
+    --focus-ring-shadow: rgba(36, 87, 207, 0.22);
+    --progress-start: #3ea76a;
+    --progress-end: #2f855a;
 }
 
-button:focus-visible,
-input:focus-visible,
+body.forest-theme {
+    --page-bg: #f4f8f3;
+    --surface-color: #ffffff;
+    --panel-color: #e3f0e7;
+    --border-color: #c4decf;
+    --text-color: #1d2a23;
+    --muted-text: #365042;
+    --completed-text: #50695a;
+    --accent-color: #2f6b2f;
+    --accent-strong: #245524;
+    --action-color: #2f6b2f;
+    --action-hover: #245524;
+    --button-text: #ffffff;
+    --neutral-button: #4b5c50;
+    --neutral-hover: #3d4d43;
+    --neutral-text: #ffffff;
+    --success-color: #2f6b2f;
+    --success-strong: #245524;
+    --danger-color: #a33a31;
+    --danger-hover: #8a2f28;
+    --input-border: #b8cfbf;
+    --shadow-soft: 0 10px 24px rgba(24, 39, 75, 0.1);
+    --card-shadow: 0 1px 3px rgba(36, 80, 55, 0.12);
+    --focus-ring-shadow: rgba(47, 107, 47, 0.22);
+    --progress-start: #2f8f58;
+    --progress-end: #2f6b2f;
+}
+
+body.ocean-theme {
+    --page-bg: #eef6f9;
+    --surface-color: #ffffff;
+    --panel-color: #deedf5;
+    --border-color: #bed9e8;
+    --text-color: #10354a;
+    --muted-text: #3b6176;
+    --completed-text: #4c7085;
+    --accent-color: #1474a8;
+    --accent-strong: #0f5d86;
+    --action-color: #1474a8;
+    --action-hover: #0f5d86;
+    --button-text: #ffffff;
+    --neutral-button: #536273;
+    --neutral-hover: #44515f;
+    --neutral-text: #ffffff;
+    --success-color: #1f7a4d;
+    --success-strong: #19643f;
+    --danger-color: #bb3d38;
+    --danger-hover: #9a322f;
+    --input-border: #b4cedd;
+    --shadow-soft: 0 10px 24px rgba(16, 53, 74, 0.15);
+    --card-shadow: 0 1px 3px rgba(16, 53, 74, 0.18);
+    --focus-ring-shadow: rgba(20, 116, 168, 0.24);
+    --progress-start: #1f9dcf;
+    --progress-end: #1474a8;
+}
+
+body.dark-theme {
+    --page-bg: #0f172a;
+    --surface-color: #111827;
+    --panel-color: #1f2937;
+    --border-color: #334155;
+    --text-color: #e2e8f0;
+    --muted-text: #cbd5e1;
+    --completed-text: #94a3b8;
+    --accent-color: #60a5fa;
+    --accent-strong: #3b82f6;
+    --action-color: #60a5fa;
+    --action-hover: #3b82f6;
+    --button-text: #0b1628;
+    --neutral-button: #334155;
+    --neutral-hover: #1f2937;
+    --neutral-text: #e2e8f0;
+    --success-color: #22c55e;
+    --success-strong: #16a34a;
+    --danger-color: #f97316;
+    --danger-hover: #ea580c;
+    --input-border: #475569;
+    --shadow-soft: 0 10px 24px rgba(0, 0, 0, 0.4);
+    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+    --focus-ring-shadow: rgba(96, 165, 250, 0.35);
+    --progress-start: #60a5fa;
+    --progress-end: #3b82f6;
+}
+
+body.high-contrast-theme,
+body[data-theme="high-contrast"] {
+    --page-bg: #000000;
+    --surface-color: #000000;
+    --panel-color: #0a0a0a;
+    --border-color: #ffffff;
+    --text-color: #ffffff;
+    --muted-text: #f5f5f5;
+    --completed-text: #cfcfcf;
+    --accent-color: #ffd60a;
+    --accent-strong: #ffb700;
+    --action-color: #ffd60a;
+    --action-hover: #ffb700;
+    --button-text: #0d0d0d;
+    --neutral-button: #ffffff;
+    --neutral-hover: #e5e5e5;
+    --neutral-text: #0d0d0d;
+    --success-color: #00e676;
+    --success-strong: #00c95c;
+    --danger-color: #ff4d4f;
+    --danger-hover: #d9363e;
+    --input-border: #ffffff;
+    --shadow-soft: none;
+    --card-shadow: 0 1px 3px rgba(255, 255, 255, 0.42);
+    --focus-ring-shadow: rgba(255, 214, 10, 0.45);
+    --progress-start: #ffd60a;
+    --progress-end: #ffd60a;
+    background-color: #000000 !important;
+    color: #ffffff !important;
+}
+
+h1 {
+    text-align: center;
+    color: var(--text-color);
+    margin: 0 0 20px;
+    letter-spacing: -0.2px;
+}
+
+.container {
+    max-width: 640px;
+    margin: 0 auto;
+    background-color: var(--surface-color);
+    padding: 24px;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow-soft);
+}
+.high-contrast-theme .container,
+[data-theme="high-contrast"] .container {
+    background-color: #000000;
+    border-color: #ffffff;
+}
+
+.theme-selector {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+    color: var(--muted-text);
+    font-weight: 600;
+}
+
+label {
+    font-weight: 600;
+}
+
+select,
+input,
+button {
+    font-family: var(--font-family);
+    font-size: 1rem;
+}
+
+select,
+input {
+    border: 1px solid var(--input-border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
 select:focus-visible,
-#taskList li button:focus-visible {
-    box-shadow: 0 0 0 3px rgba(36, 87, 207, 0.15);
+input:focus-visible {
+    outline: 3px solid var(--accent-color);
+    outline-offset: 2px;
+    border-color: var(--accent-strong);
+    box-shadow: 0 0 0 4px var(--focus-ring-shadow);
+}
+
+button {
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 12px 16px;
+    cursor: pointer;
+    font-weight: 700;
+    color: var(--neutral-text);
+    background-color: var(--neutral-button);
+    background-image: none;
+    transition: background-color 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+button:hover {
+    background-color: var(--neutral-hover);
+}
+
+button:focus-visible {
+    outline: 3px solid var(--accent-color);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px var(--focus-ring-shadow);
 }
 
 @media (prefers-contrast: more) {
@@ -27,25 +275,68 @@ select:focus-visible,
     button:focus-visible,
     input:focus-visible,
     select:focus-visible {
-        box-shadow: 0 0 0 4px #fff;
+        box-shadow: 0 0 0 4px #ffffff;
     }
 }
 
-
-
-.container {
-    max-width: 600px;
-    margin: 0 auto;
-    background-color: #fff;
-    padding: 22px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+.start-cue {
+    background: linear-gradient(145deg, var(--panel-color), var(--surface-color));
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+    box-shadow: 0 1px 4px var(--card-shadow);
+}
+.high-contrast-theme .start-cue,
+[data-theme="high-contrast"] .start-cue {
+    border-color: #ffffff;
 }
 
-h1 {
-    text-align: center;
-    color: #555;
-    margin-bottom: 20px;
+.start-cue-title {
+    margin: 0 0 8px;
+    font-weight: 800;
+    color: var(--text-color);
+    letter-spacing: 0.2px;
+}
+
+.start-cue-step {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 6px 0;
+}
+
+.start-cue-step-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background-color: var(--accent-color);
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 14px;
+}
+
+.start-cue-text {
+    margin: 0;
+    font-weight: 600;
+    color: var(--muted-text);
+}
+
+.start-cue-cta {
+    margin-top: 10px;
+    padding: 10px 14px;
+    border: 1px solid var(--accent-strong);
+    background-color: var(--action-color);
+    color: var(--button-text);
+    min-height: 44px;
+}
+
+.start-cue-cta:hover {
+    background-color: var(--action-hover);
+    transform: translateY(-1px);
 }
 
 .insights {
@@ -56,23 +347,28 @@ h1 {
 }
 
 .insight-card {
-    background: linear-gradient(145deg, #ffffff, #f2f2f2);
-    border: 1px solid #e5e5e5;
-    border-radius: 8px;
+    background: linear-gradient(145deg, var(--surface-color), var(--panel-color));
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
     padding: 12px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--card-shadow);
+}
+.high-contrast-theme .insight-card,
+[data-theme="high-contrast"] .insight-card {
+    border-color: #ffffff;
 }
 
 .insight-card .label {
     font-size: 13px;
-    color: #777;
+    color: var(--muted-text);
     margin: 0 0 6px;
+    letter-spacing: 0.1px;
 }
 
 .insight-card .value {
-    font-size: 20px;
+    font-size: 22px;
     font-weight: 700;
-    color: #333;
+    color: var(--text-color);
     margin: 0;
 }
 
@@ -93,16 +389,17 @@ h1 {
 }
 
 .progress-bar {
-    background: #ededed;
+    background: var(--panel-color);
+    border: 1px solid var(--border-color);
     border-radius: 999px;
-    height: 10px;
+    height: 12px;
     width: 100%;
     overflow: hidden;
     margin-bottom: 6px;
 }
 
 .progress-fill {
-    background: linear-gradient(90deg, #5cb85c, #4cae4c);
+    background: linear-gradient(90deg, var(--progress-start), var(--progress-end));
     height: 100%;
     width: 0;
     transition: width 0.2s ease;
@@ -110,17 +407,13 @@ h1 {
 
 .input-section {
     display: flex;
-    gap: 8px;
+    gap: 10px;
     margin-bottom: 16px;
     flex-wrap: wrap;
 }
 
 #taskInput {
     flex-grow: 1;
-    padding: 12px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 17px;
     min-width: 0;
 }
 
@@ -132,88 +425,31 @@ h1 {
 }
 
 #addTaskButton {
-    background-color: #1b5e20;
-    color: white;
-    border: none;
-    padding: 12px 18px;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 17px;
-    min-height: 46px;
+    background-color: var(--action-color);
+    color: var(--button-text);
+    border: 1px solid var(--accent-strong);
+    min-height: 48px;
+}
+.high-contrast-theme #addTaskButton,
+[data-theme="high-contrast"] #addTaskButton {
+    background: #ffd60a !important;
+    background-color: #ffd60a !important;
+    border-color: #ffb700 !important;
+    color: #0d0d0d !important;
 }
 
 #addTaskButton:hover {
-    background-color: #164a18;
-}
-
-.start-cue {
-    background: linear-gradient(145deg, #f7fbff, #eef3ff);
-    border: 1px solid #d7e3ff;
-    border-radius: 10px;
-    padding: 14px 16px;
-    margin-bottom: 16px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-}
-
-.start-cue-title {
-    margin: 0 0 8px;
-    font-weight: 800;
-    letter-spacing: 0.2px;
-}
-
-.start-cue-step {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin: 6px 0;
-}
-
-.start-cue-step-number {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    background-color: #2457cf;
-    color: #fff;
-    font-weight: 700;
-    font-size: 14px;
-}
-
-.start-cue-text {
-    margin: 0;
-    font-weight: 600;
-    color: #304165;
-}
-
-.start-cue-cta {
-    margin-top: 10px;
-    padding: 10px 14px;
-    border: 1px solid #2457cf;
-    background-color: #2457cf;
-    color: #fff;
-    border-radius: 8px;
-    cursor: pointer;
-    font-weight: 700;
-    font-size: 16px;
-    min-height: 44px;
-    transition: background-color 0.2s ease, transform 0.1s ease;
-}
-
-.start-cue-cta:hover {
-    background-color: #1f4bb6;
-    transform: translateY(-1px);
+    background-color: var(--action-hover);
 }
 
 .helper-bubble {
-    background-color: #2457cf;
-    color: #fff;
+    background-color: var(--accent-color);
+    color: #ffffff;
     border-radius: 10px;
     padding: 10px 12px;
     font-size: 14px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-    max-width: 220px;
+    box-shadow: 0 4px 8px var(--card-shadow);
+    max-width: 240px;
     position: absolute;
     left: 100%;
     top: 50%;
@@ -229,211 +465,106 @@ h1 {
     transform: translateY(-50%);
     border-width: 6px;
     border-style: solid;
-    border-color: transparent #2457cf transparent transparent;
+    border-color: transparent var(--accent-color) transparent transparent;
 }
 
 .bulk-actions {
-
     display: flex;
-
     align-items: center;
-
-    gap: 10px;
-
-    margin-bottom: 15px;
-
     gap: 8px;
-
+    margin-bottom: 15px;
     flex-wrap: wrap;
-
 }
 
-    border: 1px solid #e5e5e5;
-
+.bulk-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
     border-radius: 8px;
-
-    background-color: #fafafa;
-
-    flex: 1 1 200px;
-
-    padding: 12px;
-
-    display: flex;
-
-    border-radius: 6px;
-
-    font-size: 17px;
-
-}
-
-.bulk-toggle-label {
-
-    font-weight: 600;
-
-    color: #444;
-
-}
-
-.bulk-actions button {
-
-    background-color: #6c757d;
-
-    color: #fff;
-
-    border: none;
-
-    padding: 10px 14px;
-
-    border-radius: 0 6px 6px 0;
-
-    cursor: pointer;
-
-    font-size: 15px;
-
-    transition: background-color 0.2s ease, box-shadow 0.2s ease;
-
-}
-
-.bulk-actions button:hover {
-
-    background-color: #5a6268;
-
-}
-
-.bulk-actions button:focus-visible,
-.bulk-toggle input[type="checkbox"]:focus-visible {
-
-    outline: 3px solid #4cae4c;
-
-    outline-offset: 2px;
-
-    box-shadow: 0 0 0 4px rgba(76, 174, 76, 0.2);
-
+    background-color: var(--panel-color);
 }
 
 .bulk-toggle input[type="checkbox"] {
-
     width: 18px;
-
     height: 18px;
+    accent-color: var(--accent-color);
+}
 
+.bulk-toggle-label {
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+.bulk-actions button {
+    background-color: var(--neutral-button);
+    color: var(--neutral-text);
+    padding: 10px 14px;
+    border-radius: 10px;
+    font-size: 15px;
 }
 
 #clearCompletedButton {
-
-    background-color: #5cb85c;
-
+    background-color: var(--success-color);
+    border-color: var(--success-strong);
 }
 
 #clearCompletedButton:hover {
-
-    background-color: #4cae4c;
-
+    background-color: var(--success-strong);
 }
-
-
 
 #taskList {
     list-style-type: none;
     padding: 0;
+    margin: 0;
 }
 
 .empty-state {
-
-.empty-state {
-
-    background: linear-gradient(145deg, #ffffff, #f2f2f2);
-
-    border: 1px dashed #ccc;
-
-    border-radius: 8px;
-
+    background: linear-gradient(145deg, var(--surface-color), var(--panel-color));
+    border: 1px dashed var(--border-color);
+    border-radius: 10px;
     padding: 12px 14px;
-
-    color: #666;
-
+    color: var(--muted-text);
     margin: 10px 0;
-
-    font-size: 15px;
-
-}
-
-.empty-state p {
-
-.empty-state {
-
-    background: linear-gradient(145deg, #ffffff, #f2f2f2);
-
-    border: 1px dashed #ccc;
-
-    border-radius: 8px;
-
-    padding: 12px 14px;
-
-    color: #666;
-
-    margin: 10px 0;
-
     font-size: 16px;
-
 }
 
 .empty-state p {
-
     margin: 4px 0;
-
 }
 
-
-
-}
-
-
-
+#starterHint {
     padding: 14px;
-
     text-align: center;
-
-    background: linear-gradient(145deg, #ffffff, #f6f6f6);
-
-    border: 1px solid #e5e5e5;
-
-    border-radius: 8px;
-
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-
-    color: #555;
-
+    background: linear-gradient(145deg, var(--surface-color), var(--panel-color));
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    box-shadow: var(--card-shadow);
+    color: var(--text-color);
+    margin-bottom: 10px;
 }
 
 .empty-state-title {
-
     margin: 0 0 6px;
-
     font-weight: 700;
-
     color: inherit;
-
 }
 
 .empty-state-message {
-
     margin: 0;
-
-    color: #777;
-
+    color: var(--muted-text);
 }
 
-
-
 #taskList li {
-    padding: 10px;
-    border-bottom: 1px solid #eee;
+    padding: 12px 10px;
+    border-bottom: 1px solid var(--border-color);
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
     flex-wrap: wrap;
+    background-color: var(--surface-color);
 }
 
 #taskList li:last-child {
@@ -445,590 +576,56 @@ h1 {
     margin-right: 10px;
     word-break: break-word;
     min-width: 0;
+    color: var(--text-color);
+}
+
+#taskList li span.completed {
+    text-decoration: line-through;
+    color: var(--completed-text);
 }
 
 #taskList li button {
-    background-color: #d9534f;
-    color: white;
-    border: none;
-
+    background-color: var(--danger-color);
+    color: #ffffff;
+    border: 1px solid var(--danger-hover);
     padding: 8px 12px;
-
-    border-radius: 6px;
-
-    cursor: pointer;
-
+    border-radius: 10px;
     font-size: 15px;
-
     margin-left: 5px;
     flex-shrink: 0;
 }
 
 #taskList li button:hover {
-    background-color: #c9302c;
+    background-color: var(--danger-hover);
 }
 
 #taskList li input[type="checkbox"] {
     margin-right: 8px;
     margin-top: 2px;
+    accent-color: var(--accent-color);
 }
 
 .hidden {
     display: none;
 }
 
-
-
 .sr-only {
-
     position: absolute;
-
     width: 1px;
-
     height: 1px;
-
     padding: 0;
-
     margin: -1px;
-
     overflow: hidden;
-
     clip: rect(0, 0, 0, 0);
-
     white-space: nowrap;
-
     border: 0;
-
 }
-
-#starterHint {
-    background: #fff8e1;
-    border: 1px solid #f0d78c;
-    border-radius: 8px;
-    padding: 12px 14px;
-    margin: 10px 0 5px;
-    color: #7a5d00;
-    font-size: 16px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-}
-
-#starterHint strong {
-    color: #5c4400;
-}
-
-
 
 #wisdomDisplay {
-    margin-top: 20px;
-    padding: 15px;
-    background-color: #f9f9f9;
-    border: 1px solid #eee;
-    border-radius: 4px;
-    font-style: italic;
-    color: #777;
-}
-
-#wisdomDisplay strong {
-    font-style: normal;
-    color: #555;
-}
-
-.completed {
-    text-decoration: line-through;
-    color: #888;
-}
-
-/* Theme selector styles */
-.theme-selector {
-    margin-bottom: 15px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-}
-
-.theme-selector label {
-    margin-right: 10px;
-}
-
-.theme-selector select {
-    padding: 8px;
-    border-radius: 4px;
-    border: 1px solid #ccc;
-}
-
-@media (max-width: 600px) {
-    body {
-        margin: 12px;
-    }
-
-    .container {
-        padding: 16px;
-    }
-
-    .input-section {
-        flex-direction: column;
-    }
-
-    .cta-wrapper {
-        flex-direction: column;
-        align-items: flex-start;
-        width: 100%;
-    }
-
-    #addTaskButton {
-        width: 100%;
-    }
-
-    .helper-bubble {
-        position: static;
-        transform: none;
-        width: 100%;
-        max-width: none;
-    }
-
-    #clearCompletedButton {
-        width: 100%;
-    }
-
-    .insight-card {
-        padding: 10px;
-    }
-}
-
-/* Forest Trail Theme */
-body.forest-theme {
-    background-color: #a8dadc;
-    color: #1d3557;
-}
-
-.forest-theme .container {
-    background-color: #457b9d;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    color: #f1faee;
-}
-
-.forest-theme :focus-visible {
-
-    outline-color: #f1faee;
-
-    box-shadow: 0 0 0 3px rgba(241, 250, 238, 0.25);
-
-}
-
-
-
-.forest-theme .insight-card {
-    background: linear-gradient(145deg, #4f8ab3, #3e6f8c);
-    border: 1px solid #1d3557;
-    box-shadow: none;
-}
-
-.forest-theme .insight-card .label {
-    color: #d9e6ef;
-}
-
-.forest-theme .insight-card .value {
-    color: #f1faee;
-}
-
-.forest-theme .progress-bar {
-    background: rgba(255, 255, 255, 0.2);
-}
-
-.forest-theme .progress-fill {
-    background: linear-gradient(90deg, #f1faee, #a8dadc);
-}
-
-.forest-theme .bulk-actions {
-
-    background-color: #3e6f8c;
-
-    border-color: #1d3557;
-
-}
-
-.forest-theme .bulk-toggle-label {
-
-    color: #f1faee;
-
-}
-
-.forest-theme .bulk-actions button {
-
-    background-color: #1d3557;
-
-    color: #f1faee;
-
-}
-
-.forest-theme .bulk-actions button:hover {
-
-    background-color: #0b132b;
-
-}
-
-.forest-theme .bulk-actions button:focus-visible,
-.forest-theme .bulk-toggle input[type="checkbox"]:focus-visible {
-
-    outline-color: #f1faee;
-
-    box-shadow: 0 0 0 4px rgba(241, 250, 238, 0.25);
-
-}
-
-
-
-.forest-theme h1 {
-    color: #f1faee;
-}
-
-.forest-theme #addTaskButton {
-    background-color: #1d3557;
-    color: #f1faee;
-}
-
-.forest-theme #addTaskButton:hover {
-    background-color: #0b132b;
-}
-
-.forest-theme #taskList li {
-    border-bottom: 1px solid #a8dadc;
-}
-
-.forest-theme .completed {
-    color: #a8dadc;
-}
-
-.forest-theme #clearCompletedButton {
-    background-color: #1d3557;
-    color: #f1faee;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    margin-top: 10px;
-}
-
-.forest-theme #clearCompletedButton:hover {
-    background-color: #0b132b;
-}
-
-.forest-theme #wisdomDisplay {
-    background-color: #457b9d;
-    border: 1px solid #1d3557;
-    color: #f1faee;
-}
-
-.forest-theme #wisdomDisplay strong {
-    color: #f1faee;
-}
-
-/* Ocean Breeze Theme */
-body.ocean-theme {
-    background-color: #e0f2f7;
-    color: #0277bd;
-}
-
-.ocean-theme .container {
-    background-color: #b2ebf2;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    color: #01579b;
-}
-
-.ocean-theme :focus-visible {
-
-    outline-color: #01579b;
-
-    box-shadow: 0 0 0 3px rgba(1, 87, 155, 0.25);
-
-}
-
-
-
-.ocean-theme .insight-card {
-    background: linear-gradient(145deg, #c5f2f7, #a5dbe4);
-    border: 1px solid #0277bd;
-    box-shadow: none;
-}
-
-.ocean-theme .insight-card .label {
-    color: #0277bd;
-}
-
-.ocean-theme .insight-card .value {
-    color: #01579b;
-}
-
-.ocean-theme .progress-bar {
-    background: rgba(1, 87, 155, 0.15);
-}
-
-.ocean-theme .progress-fill {
-    background: linear-gradient(90deg, #0277bd, #039be5);
-}
-
-.ocean-theme .bulk-actions {
-
-    background-color: #c5f2f7;
-
-    border-color: #0277bd;
-
-}
-
-.ocean-theme .bulk-toggle-label {
-
-    color: #01579b;
-
-}
-
-.ocean-theme .bulk-actions button {
-
-    background-color: #0277bd;
-
-    color: #e0f2f7;
-
-}
-
-.ocean-theme .bulk-actions button:hover {
-
-    background-color: #01579b;
-
-}
-
-.ocean-theme .bulk-actions button:focus-visible,
-.ocean-theme .bulk-toggle input[type="checkbox"]:focus-visible {
-
-    outline-color: #0277bd;
-
-    box-shadow: 0 0 0 4px rgba(2, 119, 189, 0.2);
-
-}
-
-
-
-.ocean-theme h1 {
-    color: #01579b;
-}
-
-.ocean-theme #addTaskButton {
-    background-color: #0277bd;
-    color: #e0f2f7;
-}
-
-.ocean-theme #addTaskButton:hover {
-    background-color: #01579b;
-}
-
-.ocean-theme #taskList li {
-    border-bottom: 1px solid #e0f2f7;
-}
-
-.ocean-theme .completed {
-    color: #80deea;
-}
-
-.ocean-theme #clearCompletedButton {
-    background-color: #0277bd;
-    color: #e0f2f7;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    margin-top: 10px;
-}
-
-.ocean-theme #clearCompletedButton:hover {
-    background-color: #01579b;
-}
-
-.ocean-theme #wisdomDisplay {
-    background-color: #b2ebf2;
-    border: 1px solid #0277bd;
-    color: #01579b;
-}
-
-.ocean-theme #wisdomDisplay strong {
-    color: #01579b;
-}
-
-/* Midnight Sky Theme */
-body.dark-theme {
-    background-color: #212121;
-    color: #f5f5f5;
-}
-
-.dark-theme .container {
-    background-color: #424242;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
-    color: #e0e0e0;
-}
-
-.dark-theme :focus-visible {
-
-    outline-color: #b5d8ff;
-
-    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.25);
-
-}
-
-
-
-.dark-theme .insight-card {
-    background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-    border: 1px solid #616161;
-    box-shadow: none;
-}
-
-.dark-theme .insight-card .label {
-    color: #cccccc;
-}
-
-.dark-theme .insight-card .value {
-    color: #ffffff;
-}
-
-.dark-theme .progress-bar {
-    background: rgba(255, 255, 255, 0.15);
-}
-
-.dark-theme .progress-fill {
-    background: linear-gradient(90deg, #81c784, #66bb6a);
-}
-
-.dark-theme .bulk-actions {
-
-    background-color: #333333;
-
-    border-color: #616161;
-
-}
-
-.dark-theme .bulk-toggle-label {
-
-    color: #e0e0e0;
-
-}
-
-.dark-theme .bulk-actions button {
-
-    background-color: #616161;
-
-    color: #f5f5f5;
-
-}
-
-.dark-theme .bulk-actions button:hover {
-
-    background-color: #757575;
-
-}
-
-.dark-theme .bulk-actions button:focus-visible,
-.dark-theme .bulk-toggle input[type="checkbox"]:focus-visible {
-
-    outline-color: #81c784;
-
-    box-shadow: 0 0 0 4px rgba(129, 199, 132, 0.25);
-
-}
-
-
-
-.dark-theme h1 {
-    color: #e0e0e0;
-}
-
-.dark-theme #addTaskButton {
-    background-color: #616161;
-    color: #f5f5f5;
-}
-
-.dark-theme #addTaskButton:hover {
-    background-color: #757575;
-}
-
-.dark-theme #taskList li {
-    border-bottom: 1px solid #616161;
-}
-
-.dark-theme .completed {
-    color: #9e9e9e;
-}
-
-.dark-theme #clearCompletedButton {
-    background-color: #616161;
-    color: #f5f5f5;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    margin-top: 10px;
-}
-
-.dark-theme #clearCompletedButton:hover {
-    background-color: #757575;
-}
-
-.dark-theme #wisdomDisplay {
-    background-color: #424242;
-    border: 1px solid #616161;
-    color: #e0e0e0;
-}
-
-.dark-theme #wisdomDisplay strong {
-    color: #e0e0e0;
-}
-
-/* Empty state theme adjustments */
-
-.forest-theme .empty-state {
-
-    background: linear-gradient(145deg, #4f8ab3, #3e6f8c);
-
-    border: 1px solid #1d3557;
-
-    color: #f1faee;
-
-}
-
-.forest-theme .empty-state-message {
-
-    color: #d9e6ef;
-
-}
-
-.ocean-theme .empty-state {
-
-    background: linear-gradient(145deg, #c5f2f7, #a5dbe4);
-
-    border: 1px solid #0277bd;
-
-    color: #01579b;
-
-}
-
-.ocean-theme .empty-state-message {
-
-    color: #0277bd;
-
-}
-
-.dark-theme .empty-state {
-
-    background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-
-    border: 1px solid #616161;
-
-    color: #f5f5f5;
-
-}
-
-.dark-theme .empty-state-message {
-
-    color: #cccccc;
-
+    margin-top: 16px;
+    padding: 12px 14px;
+    background-color: var(--panel-color);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    color: var(--text-color);
 }


### PR DESCRIPTION
## Summary
- Increase base font size and soften the default palette with updated comfortable theming
- Simplify theme selector defaults, add a high-contrast option, and ensure selections persist
- Stabilize high-contrast button contrast by forcing explicit styling and waiting for computed contrast in tests
- Remove binary screenshot from the repository to unblock PR creation

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458ebf5ba4832fbf705dcb84d0ba38)