### PR TITLE
Enhance task selection and insights coverage

### DIFF
--- a/__tests__/insights-progress.test.js
+++ b/__tests__/insights-progress.test.js
@@ -1,0 +1,66 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const indexPath = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.beforeEach(async ({ page }) => {
+    await page.goto(indexPath);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload({ waitUntil: 'domcontentloaded' });
+});
+
+test('progress insights and aria values persist after reload', async ({ page }) => {
+    await page.fill('#taskInput', 'First task');
+    await page.click('#addTaskButton');
+    await page.fill('#taskInput', 'Second task');
+    await page.click('#addTaskButton');
+
+    await page.getByTestId('complete-checkbox').first().check();
+
+    await expect(page.getByTestId('total-count')).toHaveText('2');
+    await expect(page.getByTestId('completed-count')).toHaveText('1');
+    await expect(page.getByTestId('active-count')).toHaveText('1');
+    await expect(page.getByTestId('progress-percent')).toHaveText('50%');
+
+    const ariaBefore = await page.getByTestId('progress-bar').getAttribute('aria-valuenow');
+    const ariaTextBefore = await page.getByTestId('progress-bar').getAttribute('aria-valuetext');
+    expect(ariaBefore).toBe('50');
+    expect(ariaTextBefore).toBe('50% complete');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByTestId('total-count')).toHaveText('2');
+    await expect(page.getByTestId('completed-count')).toHaveText('1');
+    await expect(page.getByTestId('active-count')).toHaveText('1');
+    await expect(page.getByTestId('progress-percent')).toHaveText('50%');
+
+    const ariaAfter = await page.getByTestId('progress-bar').getAttribute('aria-valuenow');
+    const ariaTextAfter = await page.getByTestId('progress-bar').getAttribute('aria-valuetext');
+    expect(ariaAfter).toBe('50');
+    expect(ariaTextAfter).toBe('50% complete');
+
+    const progressFillWidth = await page.getByTestId('progress-fill').evaluate(
+        (node) => getComputedStyle(node).width
+    );
+    expect(progressFillWidth).not.toBe('0px');
+});
+
+test('theme choice persists alongside insights data', async ({ page }) => {
+    await page.fill('#taskInput', 'Persisted task');
+    await page.click('#addTaskButton');
+    await page.selectOption('#theme', 'forest');
+
+    const storedTheme = await page.evaluate(() => localStorage.getItem('journeyTheme'));
+    expect(storedTheme).toBe('forest');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    const selectedTheme = await page.$eval('#theme', (el) => el.value);
+    expect(selectedTheme).toBe('forest');
+    const datasetTheme = await page.$eval('body', (el) => el.dataset.theme);
+    expect(datasetTheme).toBe('forest');
+
+    await expect(page.getByTestId('total-count')).toHaveText('1');
+    await expect(page.getByTestId('completed-count')).toHaveText('0');
+    await expect(page.getByTestId('progress-percent')).toHaveText('0%');
+});

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 
                 <p class="label">Progress</p>
 
-                <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" data-testid="progress-bar">
 
                     <div id="progressFill" class="progress-fill" data-testid="progress-fill"></div>
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,3 @@
-console.log("JavaScript file loaded!");
-
 function computeInsights(tasks) {
     const totalTasks = tasks.length;
     const completedTasks = tasks.filter(task => task.completed).length;
@@ -156,6 +154,7 @@ if (typeof document !== 'undefined') {
         let lastDeletedTasks = [];
         let undoTimeoutId = null;
         const saveFeedback = createSaveFeedbackController(saveStatus);
+        updateUndoButtonState(false);
 
         initializeHelperBubble();
         renderTasks();
@@ -564,7 +563,10 @@ if (typeof document !== 'undefined') {
 
         function isWisdomEnabled() {
             const stored = localStorage.getItem(wisdomToggleKey);
-            if (stored === null) return true;
+            if (stored === null) {
+                localStorage.setItem(wisdomToggleKey, 'true');
+                return true;
+            }
             return stored === 'true';
         }
 


### PR DESCRIPTION
## Summary
- solidify client-side task selection, undo, and wisdom toggle behavior while keeping invalid entries from mutating state
- export pure helpers for tests and refine inline validation, selection, and progress updates for accessibility
- add stable progress hooks and new Playwright coverage for insights persistence and theme storage

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695296b1f7bc832fa805abaf2a3ff8bb)