### PR TITLE
Enhance journey input with artful themes and storytelling milestones

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
                 <option value="dark">Midnight</option>
                 <option value="high-contrast">High contrast</option>
             </select>
+            <label class="artful-toggle" for="artfulMode">
+                <input type="checkbox" id="artfulMode" aria-label="Toggle artful illustrations">
+                Artful mode
+            </label>
         </div>
 
         <div class="wisdom-toggle">
@@ -96,7 +100,36 @@
 
         <div class="input-section">
 
-            <input type="text" id="taskInput" placeholder="Add a new step in your journey..." aria-label="New journey step">
+            <div class="input-meta" aria-label="Journey step details">
+                <input type="text" id="taskInput" placeholder="Add a new step in your journey..." aria-label="New journey step description">
+                <div class="selectors">
+                    <label for="moodSelect">Mood</label>
+                    <select id="moodSelect" aria-label="Select a mood for this step">
+                        <option value="">Mood (optional)</option>
+                        <option value="bright">😊 Bright</option>
+                        <option value="calm">🧘 Calm</option>
+                        <option value="focused">🎯 Focused</option>
+                        <option value="reflective">🌙 Reflective</option>
+                    </select>
+                    <label for="categorySelect">Category</label>
+                    <select id="categorySelect" aria-label="Select a category for this step">
+                        <option value="">Category (optional)</option>
+                        <option value="wellness">Wellness</option>
+                        <option value="creative">Creative</option>
+                        <option value="planning">Planning</option>
+                        <option value="connection">Connection</option>
+                    </select>
+                    <fieldset class="priority-pill" aria-label="Set a priority for this step">
+                        <legend>Priority</legend>
+                        <div class="pill-options" role="group" aria-label="Priority options">
+                            <button type="button" class="priority" data-priority="" aria-label="No priority">None</button>
+                            <button type="button" class="priority" data-priority="low" aria-label="Low priority">Low</button>
+                            <button type="button" class="priority" data-priority="medium" aria-label="Medium priority">Medium</button>
+                            <button type="button" class="priority" data-priority="high" aria-label="High priority">High</button>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
 
             <div class="cta-wrapper">
                 <button id="addTaskButton" aria-label="Add a new journey step">Add Step</button>
@@ -123,8 +156,11 @@
         </div>
 
         <div id="emptyState" class="empty-state hidden" aria-live="polite">
-            <p><strong>Start your journey:</strong> add a step and press Enter or click “Add Step”.</p>
-            <p>Your insights and wisdom will appear once you begin tracking steps.</p>
+            <div class="carousel">
+                <p id="carouselPrompt" class="carousel-prompt"></p>
+                <button id="shufflePrompt" type="button" aria-label="Shuffle creative prompt">Shuffle</button>
+            </div>
+            <p class="carousel-caption">Let a playful prompt spark the next step in your story.</p>
         </div>
 
         <div id="starterHint" class="starter-hint hidden" role="status" aria-live="polite">
@@ -137,11 +173,17 @@
 
         <div id="wisdomDisplay" class="hidden" role="region" aria-live="polite" aria-expanded="false">
 
-            <p><strong>Wisdom for this step:</strong></p>
+            <div class="wisdom-header">
+                <p class="wisdom-title"><strong>Wisdom for this step:</strong></p>
+                <button id="refreshWisdom" type="button" aria-label="Refresh insight" class="micro-button">Refresh insight</button>
+            </div>
 
-            <p id="wisdomText"></p>
+            <p id="wisdomText" class="wisdom-quote"></p>
+            <p id="wisdomAttribution" class="wisdom-attribution"></p>
 
         </div>
+
+        <div id="milestoneStrip" class="milestone-strip" aria-label="Milestones" role="group"></div>
 
     </div>
 

--- a/script.js
+++ b/script.js
@@ -116,6 +116,44 @@ function createSaveFeedbackController(statusElement, options = {}) {
     return { trigger };
 }
 
+function deriveMilestoneState(completedCount, thresholds) {
+    const unlocked = thresholds.filter(value => completedCount >= value);
+    const next = thresholds.find(value => completedCount < value) ?? null;
+    const lastUnlocked = unlocked.length ? unlocked[unlocked.length - 1] : null;
+    return { unlocked, next, lastUnlocked };
+}
+
+function updateTaskNote(tasks, taskId, noteText) {
+    return tasks.map(task => task.id === taskId ? { ...task, note: noteText } : task);
+}
+
+function getNextOpenNoteId(currentOpenId, toggledId) {
+    if (currentOpenId === toggledId) {
+        return null;
+    }
+    return toggledId;
+}
+
+function pickQuoteForTask(task, wisdomSet) {
+    if (!task || !wisdomSet) return null;
+    const pools = [];
+    if (task.mood && Array.isArray(wisdomSet.mood?.[task.mood])) {
+        pools.push(...wisdomSet.mood[task.mood]);
+    }
+    if (task.category && Array.isArray(wisdomSet.category?.[task.category])) {
+        pools.push(...wisdomSet.category[task.category]);
+    }
+    if (task.priority && Array.isArray(wisdomSet.priority?.[task.priority])) {
+        pools.push(...wisdomSet.priority[task.priority]);
+    }
+    if (pools.length === 0) {
+        pools.push(...(wisdomSet.fallback ?? []));
+    }
+    if (pools.length === 0) return null;
+    const randomIndex = Math.floor(Math.random() * pools.length);
+    return pools[randomIndex];
+}
+
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
         const clearCompletedButton = document.getElementById('clearCompletedButton');
@@ -135,8 +173,11 @@ if (typeof document !== 'undefined') {
         const wisdomToggle = document.getElementById('wisdomToggle');
         const wisdomDisplay = document.getElementById('wisdomDisplay');
         const wisdomText = document.getElementById('wisdomText');
+        const wisdomAttribution = document.getElementById('wisdomAttribution');
+        const refreshWisdomButton = document.getElementById('refreshWisdom');
         const starterHint = document.getElementById('starterHint');
         const themeSelect = document.getElementById('theme');
+        const artfulModeToggle = document.getElementById('artfulMode');
         const bodyElement = document.body;
         const totalCount = document.getElementById('totalCount');
         const completedCount = document.getElementById('completedCount');
@@ -144,15 +185,88 @@ if (typeof document !== 'undefined') {
         const progressPercent = document.getElementById('progressPercent');
         const progressFill = document.getElementById('progressFill');
         const emptyState = document.getElementById('emptyState');
+        const carouselPrompt = document.getElementById('carouselPrompt');
+        const shufflePrompt = document.getElementById('shufflePrompt');
+        const milestoneStrip = document.getElementById('milestoneStrip');
+        const moodSelect = document.getElementById('moodSelect');
+        const categorySelect = document.getElementById('categorySelect');
+        const priorityButtons = document.querySelectorAll('.priority');
+
         const helperBubbleKey = 'journeySeenAddHelper';
         const wisdomToggleKey = 'journeyWisdomEnabled';
+        const milestoneKey = 'journeyMilestone';
+        const artfulModeKey = 'journeyArtfulMode';
         const supportedThemes = ['comfort', 'forest', 'ocean', 'dark', 'high-contrast'];
         const themeClasses = supportedThemes.map(theme => `${theme}-theme`);
         const defaultTheme = 'comfort';
+        const milestoneThresholds = [5, 10, 20];
+        const promptCarousel = [
+            'Sketch a mini ritual that makes today feel special.',
+            'Plan a 5-minute adventure that sparks curiosity.',
+            'Write a one-line story for a step you want to take.',
+            'Find a small act of kindness you can do right now.',
+            'Turn a routine into a tiny celebration today.'
+        ];
+        const wisdomQuotes = {
+            mood: {
+                bright: [
+                    { text: 'Your spark lights the path ahead.', author: 'Journey Log' },
+                    { text: 'Joy is a compass—follow where it points.', author: 'Journey Log' }
+                ],
+                calm: [
+                    { text: 'Steady breaths make steady steps.', author: 'Journey Log' },
+                    { text: 'Quiet focus is still forward motion.', author: 'Journey Log' }
+                ],
+                focused: [
+                    { text: 'Precision today, momentum tomorrow.', author: 'Journey Log' },
+                    { text: 'Aim true; the path shortens.', author: 'Journey Log' }
+                ],
+                reflective: [
+                    { text: 'Looking back helps the next stride land.', author: 'Journey Log' },
+                    { text: 'Pause, notice, and carry the insight forward.', author: 'Journey Log' }
+                ]
+            },
+            category: {
+                wellness: [
+                    { text: 'Care for your energy and the journey cares for you.', author: 'Journey Log' }
+                ],
+                creative: [
+                    { text: 'Tiny experiments build big worlds.', author: 'Journey Log' }
+                ],
+                planning: [
+                    { text: 'A map drawn today shortens tomorrow.', author: 'Journey Log' }
+                ],
+                connection: [
+                    { text: 'Bridges grow stronger one hello at a time.', author: 'Journey Log' }
+                ]
+            },
+            priority: {
+                low: [
+                    { text: 'Soft steps still leave footprints.', author: 'Journey Log' }
+                ],
+                medium: [
+                    { text: 'Balanced effort keeps you moving.', author: 'Journey Log' }
+                ],
+                high: [
+                    { text: 'When it matters most, every move counts.', author: 'Journey Log' }
+                ]
+            },
+            fallback: [
+                { text: 'The journey of a thousand miles begins with a single step.', author: 'Lao Tzu' },
+                { text: 'Believe you can and you’re halfway there.', author: 'Theodore Roosevelt' },
+                { text: 'Our greatest glory is not in never failing, but in rising up every time we fail.', author: 'Ralph Waldo Emerson' },
+                { text: 'The future belongs to those who believe in the beauty of their dreams.', author: 'Eleanor Roosevelt' }
+            ]
+        };
 
         let tasks = loadTasks();
         let lastDeletedTasks = [];
         let undoTimeoutId = null;
+        let activeWisdomTaskId = null;
+        let openNoteId = null;
+        let carouselIndex = 0;
+        let carouselTimer = null;
+        let pendingPriority = '';
         const saveFeedback = createSaveFeedbackController(saveStatus);
         updateUndoButtonState(false);
 
@@ -160,34 +274,14 @@ if (typeof document !== 'undefined') {
         renderTasks();
         const wisdomEnabled = syncWisdomPreference();
         updateWisdomVisibility(tasks, showWisdom, hideWisdom, { wisdomEnabled });
-        if (taskInput && taskInput.focus) {
-            taskInput.focus();
-        }
-
-        applyTheme(localStorage.getItem('journeyTheme'));
-
-        const wisdomQuotes = [
-            "The journey of a thousand miles begins with a single step. - Lao Tzu",
-            "The only way to do great work is to love what you do. - Steve Jobs",
-            "Believe you can and you're halfway there. - Theodore Roosevelt",
-            "Our greatest glory is not in never failing, but in rising up every time we fail. - Ralph Waldo Emerson",
-            "The future belongs to those who believe in the beauty of their dreams. - Eleanor Roosevelt"
-        ];
-
-        function revealInputSection() {
-            if (!inputSection) return;
-            inputSection.scrollIntoView({ behavior: 'auto', block: 'start' });
-            const overflow = inputSection.getBoundingClientRect().bottom - window.innerHeight + 12;
-            if (overflow > 0) {
-                window.scrollBy({ top: overflow, behavior: 'auto' });
-            }
-        }
-
         taskInput?.focus();
         revealInputSection();
+        applyTheme(localStorage.getItem('journeyTheme'));
+        syncArtfulMode();
+        startPromptCarousel();
 
         themeSelect?.addEventListener('change', (event) => applyTheme(event.target.value));
-
+        artfulModeToggle?.addEventListener('change', handleArtfulToggle);
         taskInput?.addEventListener('focus', revealInputSection);
 
         function handleAddFromInput() {
@@ -209,11 +303,18 @@ if (typeof document !== 'undefined') {
                 return;
             }
 
-            addTask(taskDescription);
+            const mood = moodSelect?.value ?? '';
+            const category = categorySelect?.value ?? '';
+            const priority = pendingPriority;
+
+            addTask(taskDescription, { mood, category, priority });
             if (taskInput) {
                 taskInput.value = '';
                 taskInput.focus();
             }
+            if (moodSelect) moodSelect.value = '';
+            if (categorySelect) categorySelect.value = '';
+            setPrioritySelection('');
             clearValidationMessage();
         }
 
@@ -233,12 +334,29 @@ if (typeof document !== 'undefined') {
             }
         });
 
-        function addTask(description) {
+        shufflePrompt?.addEventListener('click', shuffleCarouselPrompt);
+
+        priorityButtons.forEach(button => {
+            button.addEventListener('click', () => setPrioritySelection(button.dataset.priority));
+        });
+
+        refreshWisdomButton?.addEventListener('click', () => {
+            if (!activeWisdomTaskId) return;
+            const task = tasks.find(t => t.id === activeWisdomTaskId);
+            if (!task) return;
+            displayWisdomForTask(task, { forceRefresh: true });
+        });
+
+        function addTask(description, meta = {}) {
             const task = {
                 id: Date.now(),
                 description: description,
                 completed: false,
-                selected: false
+                selected: false,
+                mood: meta.mood || '',
+                category: meta.category || '',
+                priority: meta.priority || '',
+                note: ''
             };
             tasks.push(task);
             saveTasks();
@@ -283,10 +401,12 @@ if (typeof document !== 'undefined') {
                 emptyState.classList.add('hidden');
                 starterHint.classList.add('hidden');
             }
+            setPromptForEmptyState();
 
             tasks.forEach(task => {
                 const listItem = document.createElement('li');
                 listItem.dataset.taskId = task.id;
+                listItem.classList.toggle('completed', task.completed);
 
                 const selectionWrapper = document.createElement('div');
                 selectionWrapper.classList.add('selection-toggle');
@@ -311,11 +431,35 @@ if (typeof document !== 'undefined') {
                 completionCheckbox.setAttribute('aria-label', `Mark ${task.description} as completed`);
                 completionCheckbox.addEventListener('change', () => toggleComplete(task.id));
 
+                const taskContent = document.createElement('div');
+                taskContent.classList.add('task-content');
+
                 const taskSpan = document.createElement('span');
                 taskSpan.textContent = task.description;
+                taskSpan.dataset.taskId = task.id;
+                taskSpan.dataset.control = 'description';
                 if (task.completed) {
                     taskSpan.classList.add('completed');
                 }
+
+                const badgeRow = document.createElement('div');
+                badgeRow.classList.add('badge-row');
+                appendBadgeIfValue(badgeRow, task.mood, 'mood');
+                appendBadgeIfValue(badgeRow, task.category, 'category');
+                appendBadgeIfValue(badgeRow, task.priority, 'priority');
+                if (task.note && task.note.trim().length > 0) {
+                    appendBadgeIfValue(badgeRow, 'note', 'note');
+                }
+
+                const noteToggle = document.createElement('button');
+                noteToggle.type = 'button';
+                noteToggle.classList.add('note-toggle');
+                noteToggle.dataset.taskId = task.id;
+                noteToggle.dataset.control = 'note-toggle';
+                noteToggle.setAttribute('aria-expanded', openNoteId === task.id ? 'true' : 'false');
+                noteToggle.setAttribute('aria-label', task.note ? `Edit note for ${task.description}` : `Add note for ${task.description}`);
+                noteToggle.textContent = task.note ? 'Note added' : 'Add note';
+                noteToggle.addEventListener('click', () => toggleNote(task.id));
 
                 const deleteButton = document.createElement('button');
                 deleteButton.textContent = 'Delete';
@@ -324,18 +468,52 @@ if (typeof document !== 'undefined') {
                 deleteButton.setAttribute('aria-label', `Delete ${task.description}`);
                 deleteButton.addEventListener('click', () => deleteTask(task.id));
 
+                const noteContainer = document.createElement('div');
+                noteContainer.classList.add('note-container');
+                if (openNoteId !== task.id) {
+                    noteContainer.classList.add('hidden');
+                }
+
+                const noteLabel = document.createElement('label');
+                noteLabel.classList.add('sr-only');
+                noteLabel.setAttribute('for', `note-${task.id}`);
+                noteLabel.textContent = `Note for ${task.description}`;
+
+                const noteInput = document.createElement('textarea');
+                noteInput.id = `note-${task.id}`;
+                noteInput.value = task.note ?? '';
+                noteInput.dataset.taskId = task.id;
+                noteInput.dataset.control = 'note-input';
+                noteInput.setAttribute('aria-label', `Add a note for ${task.description}`);
+                noteInput.addEventListener('input', (event) => handleNoteInput(task.id, event.target.value));
+
+                noteContainer.appendChild(noteLabel);
+                noteContainer.appendChild(noteInput);
+
+                taskContent.appendChild(taskSpan);
+                if (badgeRow.children.length > 0) {
+                    taskContent.appendChild(badgeRow);
+                }
+                taskContent.appendChild(noteToggle);
+                taskContent.appendChild(noteContainer);
+
                 listItem.appendChild(selectionWrapper);
                 listItem.appendChild(completionCheckbox);
-                listItem.appendChild(taskSpan);
+                listItem.appendChild(taskContent);
                 listItem.appendChild(deleteButton);
+
+                listItem.addEventListener('focusin', () => handleTaskFocus(task.id));
+
                 taskList.appendChild(listItem);
             });
-            updateInsights(tasks, { totalCount, completedCount, activeCount, progressPercent, progressFill });
+            const insightData = updateInsights(tasks, { totalCount, completedCount, activeCount, progressPercent, progressFill });
+            updateMilestones(insightData.completedTasks);
             syncSelectAllCheckbox();
             updateSelectionActions();
             if (focusTarget) {
                 restoreFocus(focusTarget);
             }
+            updateWisdomVisibility(tasks, showWisdom, hideWisdom, { wisdomEnabled: isWisdomEnabled() });
         }
 
         function toggleComplete(taskId) {
@@ -345,7 +523,13 @@ if (typeof document !== 'undefined') {
             );
             saveTasks();
             renderTasks(focusTarget);
-            updateWisdomVisibility(tasks, showWisdom, hideWisdom, { wisdomEnabled: isWisdomEnabled() });
+            const target = tasks.find(task => task.id === taskId);
+            if (target?.completed) {
+                displayWisdomForTask(target);
+            } else if (activeWisdomTaskId === taskId) {
+                activeWisdomTaskId = null;
+                hideWisdom();
+            }
         }
 
         function toggleSelection(taskId, isSelected) {
@@ -381,7 +565,11 @@ if (typeof document !== 'undefined') {
                 id: task.id,
                 description: task.description,
                 completed: !!task.completed,
-                selected: !!task.selected
+                selected: !!task.selected,
+                mood: task.mood || '',
+                category: task.category || '',
+                priority: task.priority || '',
+                note: task.note ?? ''
             };
         }
 
@@ -405,16 +593,26 @@ if (typeof document !== 'undefined') {
 
         function showWisdom() {
             if (!wisdomDisplay || !wisdomText) return;
-            const randomIndex = Math.floor(Math.random() * wisdomQuotes.length);
-            wisdomText.textContent = wisdomQuotes[randomIndex];
             wisdomDisplay.classList.remove('hidden');
             wisdomDisplay.setAttribute('aria-expanded', 'true');
+            if (activeWisdomTaskId) {
+                const task = tasks.find(t => t.id === activeWisdomTaskId);
+                if (task) {
+                    displayWisdomForTask(task, { forceRefresh: true });
+                    return;
+                }
+            }
+            const fallbackQuote = pickQuoteForTask({ mood: '', category: '', priority: '' }, wisdomQuotes);
+            if (fallbackQuote) {
+                renderWisdomText(fallbackQuote);
+            }
         }
 
         function hideWisdom() {
             if (!wisdomDisplay || !wisdomText) return;
             wisdomDisplay.classList.add('hidden');
             wisdomText.textContent = '';
+            wisdomAttribution.textContent = '';
             wisdomDisplay.setAttribute('aria-expanded', 'false');
         }
 
@@ -637,17 +835,232 @@ if (typeof document !== 'undefined') {
                 }
                 bodyElement.style.setProperty('background-color', '#000000', 'important');
                 bodyElement.style.setProperty('color', '#ffffff', 'important');
+                if (artfulModeToggle) {
+                    artfulModeToggle.checked = false;
+                    artfulModeToggle.disabled = true;
+                    localStorage.setItem(artfulModeKey, 'false');
+                    updateArtfulState();
+                }
             } else {
                 if (addTaskButton) {
                     addTaskButton.style.cssText = '';
                 }
                 bodyElement.style.removeProperty('background-color');
                 bodyElement.style.removeProperty('color');
+                if (artfulModeToggle) {
+                    artfulModeToggle.disabled = false;
+                }
+                syncArtfulMode();
             }
             if (themeSelect && themeSelect.value !== normalizedTheme) {
                 themeSelect.value = normalizedTheme;
             }
             localStorage.setItem('journeyTheme', normalizedTheme);
+        }
+
+        function syncArtfulMode() {
+            if (!artfulModeToggle) return;
+            const stored = localStorage.getItem(artfulModeKey);
+            const normalizedTheme = bodyElement.dataset.theme || defaultTheme;
+            const defaultEnabled = normalizedTheme === 'high-contrast' ? false : (stored === 'true');
+            artfulModeToggle.checked = normalizedTheme === 'high-contrast' ? false : defaultEnabled;
+            updateArtfulState();
+        }
+
+        function handleArtfulToggle() {
+            if (!artfulModeToggle) return;
+            localStorage.setItem(artfulModeKey, artfulModeToggle.checked ? 'true' : 'false');
+            updateArtfulState();
+        }
+
+        function updateArtfulState() {
+            const isArtful = artfulModeToggle?.checked ?? false;
+            if (isArtful) {
+                bodyElement.classList.add('artful-mode');
+                bodyElement.dataset.artful = 'on';
+            } else {
+                bodyElement.classList.remove('artful-mode');
+                bodyElement.dataset.artful = 'off';
+            }
+        }
+
+        function appendBadgeIfValue(container, value, type) {
+            if (!value) return;
+            const badge = document.createElement('span');
+            badge.classList.add('meta-badge', `badge-${type}`);
+            badge.textContent = getBadgeLabel(type, value);
+            container.appendChild(badge);
+        }
+
+        function getBadgeLabel(type, value) {
+            const map = {
+                mood: {
+                    bright: '😊 Bright',
+                    calm: '🧘 Calm',
+                    focused: '🎯 Focused',
+                    reflective: '🌙 Reflective'
+                },
+                category: {
+                    wellness: 'Wellness',
+                    creative: 'Creative',
+                    planning: 'Planning',
+                    connection: 'Connection'
+                },
+                priority: {
+                    low: 'Low priority',
+                    medium: 'Medium priority',
+                    high: 'High priority'
+                }
+            };
+            if (type === 'note') return 'Note';
+            return map[type]?.[value] ?? value;
+        }
+
+        function setPrioritySelection(priority) {
+            pendingPriority = priority || '';
+            priorityButtons.forEach(button => {
+                button.classList.toggle('active', button.dataset.priority === pendingPriority);
+            });
+        }
+
+        function revealInputSection() {
+            if (!inputSection) return;
+            inputSection.scrollIntoView({ behavior: 'auto', block: 'start' });
+            const overflow = inputSection.getBoundingClientRect().bottom - window.innerHeight + 12;
+            if (overflow > 0) {
+                window.scrollBy({ top: overflow, behavior: 'auto' });
+            }
+        }
+
+        function updateMilestones(completedCount) {
+            if (!milestoneStrip) return;
+            const state = deriveMilestoneState(completedCount, milestoneThresholds);
+            const lastStored = Number(localStorage.getItem(milestoneKey)) || 0;
+            milestoneStrip.innerHTML = '';
+            milestoneThresholds.forEach(value => {
+                const marker = document.createElement('div');
+                marker.classList.add('milestone-marker');
+                const isUnlocked = state.unlocked.includes(value);
+                marker.dataset.value = value;
+                marker.setAttribute('role', 'button');
+                marker.setAttribute('tabindex', '0');
+                marker.setAttribute('aria-label', `Milestone at ${value} completed steps`);
+                const label = document.createElement('span');
+                label.textContent = `${value}`;
+                marker.appendChild(label);
+                if (isUnlocked) {
+                    marker.classList.add('unlocked');
+                }
+                if (isUnlocked) {
+                    marker.title = `Unlocked milestone ${value}`;
+                } else if (state.next === value) {
+                    marker.title = `Unlocks at ${value} completed steps`;
+                } else {
+                    marker.title = `Milestone at ${value} completed steps`;
+                }
+                milestoneStrip.appendChild(marker);
+                marker.addEventListener('click', () => handleTaskFocusFromMilestone(value));
+                marker.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        handleTaskFocusFromMilestone(value);
+                    }
+                });
+                if (state.lastUnlocked === value && value > lastStored) {
+                    marker.classList.add('milestone-flare');
+                    setTimeout(() => marker.classList.remove('milestone-flare'), 2400);
+                    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                        milestoneStrip.classList.add('confetti');
+                        setTimeout(() => milestoneStrip.classList.remove('confetti'), 1200);
+                    }
+                    localStorage.setItem(milestoneKey, String(value));
+                }
+            });
+        }
+
+        function handleTaskFocusFromMilestone(value) {
+            const task = tasks.find(t => t.completed);
+            if (task) {
+                displayWisdomForTask(task);
+            }
+        }
+
+        function handleTaskFocus(taskId) {
+            const task = tasks.find(t => t.id === taskId);
+            if (!task) return;
+            if (task.completed) {
+                activeWisdomTaskId = taskId;
+                displayWisdomForTask(task);
+            } else if (activeWisdomTaskId === taskId) {
+                activeWisdomTaskId = null;
+                hideWisdom();
+            }
+        }
+
+        function displayWisdomForTask(task, options = {}) {
+            const wisdomEnabled = isWisdomEnabled();
+            if (!wisdomEnabled || !task.completed) {
+                hideWisdom();
+                return;
+            }
+            activeWisdomTaskId = task.id;
+            const quote = pickQuoteForTask(task, wisdomQuotes) || pickQuoteForTask({}, wisdomQuotes);
+            if (!quote) return;
+            renderWisdomText(quote, options.forceRefresh);
+            showWisdom();
+        }
+
+        function renderWisdomText(quote, force) {
+            if (!wisdomText || !wisdomAttribution) return;
+            if (!force && wisdomText.textContent === quote.text) return;
+            wisdomText.textContent = quote.text;
+            wisdomAttribution.textContent = quote.author ? `— ${quote.author}` : '';
+        }
+
+        function toggleNote(taskId) {
+            openNoteId = getNextOpenNoteId(openNoteId, taskId);
+            renderTasks();
+        }
+
+        function handleNoteInput(taskId, value) {
+            tasks = updateTaskNote(tasks, taskId, value);
+            saveTasks();
+            renderTasks({ taskId, control: 'note-input' });
+        }
+
+        function startPromptCarousel() {
+            if (!carouselPrompt) return;
+            carouselPrompt.textContent = promptCarousel[carouselIndex];
+            if (carouselTimer) {
+                clearInterval(carouselTimer);
+            }
+            carouselTimer = setInterval(() => {
+                if (tasks.length === 0) {
+                    shuffleCarouselPrompt();
+                }
+            }, 8000);
+        }
+
+        function shuffleCarouselPrompt() {
+            if (!carouselPrompt) return;
+            carouselIndex = (carouselIndex + 1) % promptCarousel.length;
+            carouselPrompt.textContent = promptCarousel[carouselIndex];
+        }
+
+        function handleTaskListEmpty() {
+            if (tasks.length === 0) {
+                emptyState?.setAttribute('aria-live', 'polite');
+            } else {
+                emptyState?.setAttribute('aria-live', 'off');
+            }
+        }
+
+        function setPromptForEmptyState() {
+            if (!emptyState) return;
+            handleTaskListEmpty();
+            if (tasks.length === 0 && carouselPrompt) {
+                carouselPrompt.textContent = promptCarousel[carouselIndex];
+            }
         }
 
         clearCompletedButton?.addEventListener('click', clearCompletedTasks);
@@ -659,7 +1072,12 @@ if (typeof document !== 'undefined') {
             const newValue = wisdomToggle.checked;
             localStorage.setItem(wisdomToggleKey, newValue ? 'true' : 'false');
             updateWisdomVisibility(tasks, showWisdom, hideWisdom, { wisdomEnabled: newValue });
+            if (!newValue) {
+                hideWisdom();
+            }
         });
+
+        setPromptForEmptyState();
     });
 }
 
@@ -671,6 +1089,10 @@ if (typeof module !== 'undefined') {
         toggleAllTasks,
         getSelectAllState,
         createSaveFeedbackController,
-        restoreDeletedTasks
+        restoreDeletedTasks,
+        deriveMilestoneState,
+        updateTaskNote,
+        getNextOpenNoteId,
+        pickQuoteForTask
     };
 }

--- a/style.css
+++ b/style.css
@@ -37,6 +37,25 @@ body {
     background-color: var(--page-bg);
     color: var(--text-color);
     transition: background-color 0.3s ease, color 0.3s ease;
+    background-image:
+        radial-gradient(circle at 20% 20%, rgba(28, 58, 138, 0.06), transparent 35%),
+        radial-gradient(circle at 80% 10%, rgba(47, 143, 88, 0.08), transparent 40%),
+        radial-gradient(circle at 60% 80%, rgba(20, 116, 168, 0.05), transparent 35%);
+    background-size: cover;
+    background-repeat: no-repeat;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-size: cover;
+    background-repeat: no-repeat;
+    opacity: 0.14;
+    transition: opacity 0.25s ease;
 }
 
 body.comfort-theme {
@@ -65,6 +84,10 @@ body.comfort-theme {
     --focus-ring-shadow: rgba(36, 87, 207, 0.22);
     --progress-start: #3ea76a;
     --progress-end: #2f855a;
+    background-image:
+        radial-gradient(circle at 12% 24%, rgba(28, 58, 138, 0.09), transparent 26%),
+        radial-gradient(circle at 82% 12%, rgba(255, 214, 10, 0.08), transparent 30%),
+        radial-gradient(circle at 48% 86%, rgba(63, 167, 106, 0.12), transparent 35%);
 }
 
 body.forest-theme {
@@ -93,6 +116,10 @@ body.forest-theme {
     --focus-ring-shadow: rgba(47, 107, 47, 0.22);
     --progress-start: #2f8f58;
     --progress-end: #2f6b2f;
+    background-image:
+        radial-gradient(circle at 14% 18%, rgba(47, 107, 47, 0.12), transparent 28%),
+        radial-gradient(circle at 82% 20%, rgba(61, 106, 69, 0.1), transparent 32%),
+        radial-gradient(circle at 56% 80%, rgba(159, 201, 164, 0.12), transparent 36%);
 }
 
 body.ocean-theme {
@@ -121,6 +148,10 @@ body.ocean-theme {
     --focus-ring-shadow: rgba(20, 116, 168, 0.24);
     --progress-start: #1f9dcf;
     --progress-end: #1474a8;
+    background-image:
+        radial-gradient(circle at 18% 20%, rgba(20, 116, 168, 0.15), transparent 30%),
+        radial-gradient(circle at 80% 10%, rgba(52, 152, 219, 0.14), transparent 32%),
+        radial-gradient(circle at 60% 86%, rgba(16, 53, 74, 0.12), transparent 36%);
 }
 
 body.dark-theme {
@@ -149,6 +180,10 @@ body.dark-theme {
     --focus-ring-shadow: rgba(96, 165, 250, 0.35);
     --progress-start: #60a5fa;
     --progress-end: #3b82f6;
+    background-image:
+        radial-gradient(circle at 12% 24%, rgba(96, 165, 250, 0.2), transparent 28%),
+        radial-gradient(circle at 86% 16%, rgba(59, 130, 246, 0.18), transparent 32%),
+        radial-gradient(circle at 52% 80%, rgba(34, 197, 94, 0.08), transparent 34%);
 }
 
 body.high-contrast-theme,
@@ -180,6 +215,32 @@ body[data-theme="high-contrast"] {
     --progress-end: #ffd60a;
     background-color: #000000 !important;
     color: #ffffff !important;
+    background-image: none;
+}
+
+body.artful-mode::before {
+    opacity: 0.32;
+}
+
+body.comfort-theme.artful-mode::before {
+    background-image: radial-gradient(circle at 20% 30%, rgba(28, 58, 138, 0.25) 0, transparent 40%), linear-gradient(135deg, rgba(255, 214, 10, 0.2), rgba(28, 58, 138, 0.15));
+}
+
+body.forest-theme.artful-mode::before {
+    background-image: radial-gradient(circle at 16% 22%, rgba(47, 107, 47, 0.2) 0, transparent 44%), linear-gradient(135deg, rgba(47, 143, 88, 0.16), rgba(36, 80, 55, 0.2));
+}
+
+body.ocean-theme.artful-mode::before {
+    background-image: radial-gradient(circle at 16% 22%, rgba(20, 116, 168, 0.22) 0, transparent 46%), linear-gradient(135deg, rgba(15, 93, 134, 0.16), rgba(16, 53, 74, 0.2));
+}
+
+body.dark-theme.artful-mode::before {
+    background-image: radial-gradient(circle at 18% 24%, rgba(96, 165, 250, 0.35) 0, transparent 42%), linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(59, 130, 246, 0.22));
+}
+
+body.high-contrast-theme.artful-mode::before {
+    background-image: none;
+    opacity: 0;
 }
 
 h1 {
@@ -197,11 +258,19 @@ h1 {
     border-radius: 12px;
     border: 1px solid var(--border-color);
     box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
 }
+
 .high-contrast-theme .container,
 [data-theme="high-contrast"] .container {
     background-color: #000000;
     border-color: #ffffff;
+}
+
+.container > * {
+    position: relative;
+    z-index: 1;
 }
 
 .theme-selector {
@@ -211,6 +280,7 @@ h1 {
     margin-bottom: 16px;
     color: var(--muted-text);
     font-weight: 600;
+    flex-wrap: wrap;
 }
 
 label {
@@ -235,7 +305,8 @@ input {
 }
 
 select:focus-visible,
-input:focus-visible {
+input:focus-visible,
+textarea:focus-visible {
     outline: 3px solid var(--accent-color);
     outline-offset: 2px;
     border-color: var(--accent-strong);
@@ -274,7 +345,8 @@ button:focus-visible {
 
     button:focus-visible,
     input:focus-visible,
-    select:focus-visible {
+    select:focus-visible,
+    textarea:focus-visible {
         box-shadow: 0 0 0 4px #ffffff;
     }
 }
@@ -287,6 +359,7 @@ button:focus-visible {
     margin-bottom: 16px;
     box-shadow: 0 1px 4px var(--card-shadow);
 }
+
 .high-contrast-theme .start-cue,
 [data-theme="high-contrast"] .start-cue {
     border-color: #ffffff;
@@ -339,14 +412,6 @@ button:focus-visible {
     transform: translateY(-1px);
 }
 
-.theme-selector {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    margin-bottom: 16px;
-    flex-wrap: wrap;
-}
-
 .theme-selector label {
     font-weight: 600;
 }
@@ -357,6 +422,14 @@ button:focus-visible {
     border-radius: 8px;
     min-height: 44px;
     font-size: 16px;
+}
+
+.artful-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+    color: var(--muted-text);
 }
 
 .insights {
@@ -373,6 +446,12 @@ button:focus-visible {
     line-height: 1.5;
 }
 
+.insights-note {
+    margin: 0 0 16px;
+    color: var(--muted-text);
+    font-size: 14px;
+}
+
 .insight-card {
     background: linear-gradient(145deg, var(--surface-color), var(--panel-color));
     border: 1px solid var(--border-color);
@@ -380,6 +459,7 @@ button:focus-visible {
     padding: 12px;
     box-shadow: var(--card-shadow);
 }
+
 .high-contrast-theme .insight-card,
 [data-theme="high-contrast"] .insight-card {
     border-color: #ffffff;
@@ -440,6 +520,55 @@ button:focus-visible {
     align-items: stretch;
 }
 
+.input-meta {
+    flex: 1 1 380px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.selectors {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+    align-items: center;
+}
+
+.priority-pill {
+    border: 1px dashed var(--border-color);
+    border-radius: 10px;
+    padding: 8px 10px;
+    margin: 0;
+}
+
+.priority-pill legend {
+    font-size: 13px;
+    color: var(--muted-text);
+    padding: 0 6px;
+}
+
+.pill-options {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.priority {
+    background-color: var(--panel-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    padding: 8px 12px;
+    border-radius: 999px;
+    font-weight: 700;
+}
+
+.priority.active {
+    background-color: var(--accent-color);
+    border-color: var(--accent-strong);
+    color: var(--button-text);
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+}
+
 #taskInput {
     flex-grow: 1;
     min-width: 0;
@@ -483,6 +612,7 @@ button:focus-visible {
     border: 1px solid var(--accent-strong);
     min-height: 48px;
 }
+
 .high-contrast-theme #addTaskButton,
 [data-theme="high-contrast"] #addTaskButton {
     background: #ffd60a !important;
@@ -564,6 +694,49 @@ button:focus-visible {
     font-size: 15px;
 }
 
+.carousel {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.carousel-prompt {
+    margin: 0;
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+.carousel-caption {
+    margin: 6px 0 0;
+    color: var(--muted-text);
+}
+
+#secondaryAddButton {
+    display: none;
+}
+
+.secondary-add {
+    display: none;
+}
+
+@media (max-width: 560px) {
+    #secondaryAddButton,
+    .secondary-add {
+        display: block;
+        width: auto;
+        position: fixed;
+        left: 16px;
+        right: 16px;
+        bottom: 12px;
+        margin-top: 8px;
+        z-index: 6;
+    }
+
+    .input-section {
+        padding-bottom: 80px;
+    }
+}
+
 #clearCompletedButton {
     background-color: var(--success-color);
     border-color: var(--success-strong);
@@ -579,7 +752,7 @@ button:focus-visible {
     margin: 0;
 }
 
-.empty-state {
+#emptyState {
     background: linear-gradient(145deg, var(--surface-color), var(--panel-color));
     border: 1px dashed var(--border-color);
     border-radius: 10px;
@@ -589,7 +762,7 @@ button:focus-visible {
     font-size: 16px;
 }
 
-.empty-state p {
+#emptyState p {
     margin: 4px 0;
 }
 
@@ -604,15 +777,49 @@ button:focus-visible {
     margin-bottom: 10px;
 }
 
-.empty-state-title {
-    margin: 0 0 6px;
-    font-weight: 700;
-    color: inherit;
+.badge-row {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin: 6px 0 0;
 }
 
-.empty-state-message {
-    margin: 0;
-    color: var(--muted-text);
+.meta-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 700;
+    background-color: var(--panel-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    animation: badgeIn 0.24s ease both;
+}
+
+.badge-mood {
+    background-color: rgba(28, 58, 138, 0.12);
+    color: var(--accent-strong);
+    border-color: rgba(28, 58, 138, 0.24);
+}
+
+.badge-category {
+    background-color: rgba(47, 143, 88, 0.12);
+    color: var(--success-strong);
+    border-color: rgba(47, 143, 88, 0.24);
+}
+
+.badge-priority {
+    background-color: rgba(255, 214, 10, 0.16);
+    color: #7a5300;
+    border-color: rgba(255, 214, 10, 0.32);
+}
+
+.badge-note {
+    background-color: rgba(20, 116, 168, 0.12);
+    color: var(--accent-strong);
+    border-color: rgba(20, 116, 168, 0.24);
 }
 
 #taskList li {
@@ -626,6 +833,10 @@ button:focus-visible {
     background-color: var(--surface-color);
 }
 
+#taskList li.completed {
+    background: linear-gradient(145deg, var(--surface-color), rgba(47, 143, 88, 0.05));
+}
+
 #taskList li:last-child {
     border-bottom: none;
 }
@@ -633,6 +844,13 @@ button:focus-visible {
 .selection-toggle {
     display: flex;
     align-items: center;
+}
+
+.task-content {
+    flex: 1 1 300px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 #taskList li span {
@@ -659,6 +877,30 @@ button:focus-visible {
     flex-shrink: 0;
 }
 
+.note-toggle {
+    align-self: flex-start;
+    background-color: var(--panel-color);
+    border-color: var(--border-color);
+    color: var(--text-color);
+    font-size: 14px;
+    padding: 6px 10px;
+}
+
+.note-container {
+    width: 100%;
+}
+
+.note-container textarea {
+    width: 100%;
+    min-height: 90px;
+    border: 1px solid var(--input-border);
+    border-radius: 10px;
+    padding: 10px;
+    font-family: var(--font-family);
+    background-color: var(--surface-color);
+    resize: vertical;
+}
+
 #taskList li button:hover {
     background-color: var(--danger-hover);
 }
@@ -671,6 +913,14 @@ button:focus-visible {
 
 .hidden {
     display: none;
+}
+
+.micro-button {
+    padding: 6px 10px;
+    font-size: 14px;
+    background-color: var(--panel-color);
+    border-color: var(--border-color);
+    color: var(--text-color);
 }
 
 .sr-only {
@@ -707,4 +957,105 @@ button:focus-visible {
     border: 1px solid var(--border-color);
     border-radius: 10px;
     color: var(--text-color);
+}
+
+.wisdom-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.wisdom-quote {
+    font-size: 18px;
+    font-weight: 700;
+    margin: 6px 0 0;
+}
+
+.wisdom-attribution {
+    margin: 4px 0 0;
+    color: var(--muted-text);
+    font-style: italic;
+}
+
+.milestone-strip {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 16px;
+    position: relative;
+}
+
+.milestone-marker {
+    position: relative;
+    padding: 12px 10px;
+    text-align: center;
+    border: 1px dashed var(--border-color);
+    border-radius: 12px;
+    background: var(--surface-color);
+    cursor: pointer;
+    transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.milestone-marker:hover,
+.milestone-marker:focus-visible {
+    transform: translateY(-2px);
+    border-color: var(--accent-color);
+    box-shadow: 0 8px 14px rgba(0, 0, 0, 0.08);
+    outline: none;
+}
+
+.milestone-marker.unlocked {
+    background: linear-gradient(135deg, rgba(47, 143, 88, 0.15), var(--surface-color));
+    border-style: solid;
+    border-color: var(--success-color);
+    color: var(--success-strong);
+    font-weight: 800;
+}
+
+.milestone-marker.milestone-flare {
+    animation: flare 1.6s ease;
+}
+
+.milestone-strip.confetti::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: radial-gradient(circle, rgba(255, 214, 10, 0.5) 2px, transparent 3px), radial-gradient(circle, rgba(47, 143, 88, 0.5) 2px, transparent 3px), radial-gradient(circle, rgba(20, 116, 168, 0.5) 2px, transparent 3px);
+    background-size: 18px 18px, 20px 20px, 22px 22px;
+    animation: confettiFall 0.9s ease forwards;
+}
+
+@keyframes badgeIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes flare {
+    0% { box-shadow: 0 0 0 rgba(47, 143, 88, 0.4); }
+    50% { box-shadow: 0 0 18px rgba(47, 143, 88, 0.6); }
+    100% { box-shadow: 0 0 0 rgba(47, 143, 88, 0.0); }
+}
+
+@keyframes confettiFall {
+    from { opacity: 0.6; transform: translateY(-8px); }
+    to { opacity: 0; transform: translateY(12px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+
+    body::before {
+        opacity: 0.12;
+    }
 }


### PR DESCRIPTION
## Summary
- add mood/category/priority selectors, note capture, creative prompt carousel, and refreshable wisdom display to enrich each task
- introduce structured wisdom matching, milestone tracking with flare persistence, and stored task metadata including notes
- style artful theme backdrops, metadata badges, milestone strip animations, and mobile-friendly sticky add controls

## Testing
- npm test -- --reporter=line

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a3773000832fb048cdceb2240147)