### PR TITLE
Align README wording to in-product "High contrast" label

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Journey Log is a creative-first checklist that treats tasks as steps in your sto
 - **Inline micro-journaling:** Add quick notes to any step without leaving the list. Notes autosave and reveal a subtle badge when present.
 - **Creative prompts and milestones:** An empty-state carousel offers spark-ready prompts, while a milestone strip celebrates progress at 5/10/20 completed steps with gentle flares (respecting reduced-motion preferences).
 - **Contextual wisdom:** Completing a step unlocks a tailored quote based on its mood, category, or priority. Refresh the insight without toggling completion.
-- **Theme + artful mode:** Comfort, Forest, Ocean, Midnight, and High-contrast themes adapt typography, gradients, and cards. Toggle “Artful mode” to layer illustrations (automatically disabled for high-contrast for accessibility).
+- **Theme + artful mode:** Comfort, Forest, Ocean, Midnight, and High contrast themes adapt typography, gradients, and cards. Toggle “Artful mode” to layer illustrations (automatically disabled for High contrast for accessibility).
 - **Bulk selection and undo:** Select steps independently from completion status, clear selected or completed items, and undo recent deletes within the grace window.
 - **Keyboard-friendly:** Press Enter in the input to add a step, or use Ctrl/Cmd + Enter to add from anywhere. Use Ctrl/Cmd + Shift + C to clear completed steps.
 - **Persistent insights:** Total, active, completed counts and a live progress bar stay in sync with your actions and retain state via localStorage.


### PR DESCRIPTION
### Motivation

- Align documentation with the in-product theme label `High contrast` so naming is consistent across UI and docs.
- Match capitalization and spacing in the accessibility note to reduce confusion.
- Verify other repository references to ensure consistent phrasing.
- Keep this as a documentation-only update with no UX code changes.

### Description

- Replace `High-contrast` with `High contrast` in the `README.md` feature list and accessibility sentence.
- Only `README.md` was modified; no source code or assets were changed.
- Ran repository searches to confirm other occurrences and left in-product identifiers (e.g., `high-contrast` values) unchanged.
- Change was committed with the message `Align High contrast wording`.

### Testing

- No automated tests were run for this documentation-only change.
- The repository includes Playwright tests runnable via `npm test`, which were not executed for this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d554b45cc832fa2eedc4bf065b283)