### PR TITLE
Sync Clear Selected button state and ARIA on render and selection changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -299,6 +299,7 @@ if (typeof document !== 'undefined') {
 
         initializeHelperBubble();
         renderTasks();
+        updateSelectionActions();
         const wisdomEnabled = syncWisdomPreference();
         updateWisdomVisibility(tasks, showWisdom, hideWisdom, { wisdomEnabled });
         taskInput?.focus();
@@ -728,10 +729,11 @@ if (typeof document !== 'undefined') {
         }
 
         function updateSelectionActions() {
-            if (clearSelectedButton) {
-                const selectedCount = tasks.filter(task => task.selected).length;
-                clearSelectedButton.disabled = selectedCount === 0;
-            }
+            if (!clearSelectedButton) return;
+            const selectedCount = tasks.filter(task => task.selected).length;
+            const disableActions = selectedCount === 0;
+            clearSelectedButton.disabled = disableActions;
+            clearSelectedButton.setAttribute('aria-disabled', disableActions ? 'true' : 'false');
         }
 
         function rememberDeletedTasks(removedTasks) {


### PR DESCRIPTION
### Motivation

- Ensure the bulk `Clear selected` action starts disabled after initial render and re-disables when no tasks are selected. 
- Keep the visible `disabled` state and accessibility state consistent so assistive tech sees the correct affordance. 
- Centralize selection-action updates so selection changes and select-all interactions drive the same behavior. 

### Description

- Call `updateSelectionActions()` immediately after the initial `renderTasks()` so the `Clear selected` button reflects the initial task state. 
- Tighten `updateSelectionActions()` to early-return when the button is missing and to compute `selectedCount` and `disableActions` from `tasks`. 
- Set both the DOM `disabled` property and the `aria-disabled` attribute on `clearSelectedButton` so accessibility state stays in sync. 

### Testing

- Ran the automated test suite with `npm test`. 
- Unit helpers and many tests passed locally (18 tests passed). 
- Some Playwright-driven tests failed to launch because browsers are not installed in this environment, causing 20 failures with the error instructing to run `npx playwright install` to run the full suite. 
- Re-running `npm test` after `npx playwright install` should allow the full end-to-end suite to run in CI or a developer environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5675e494832facd57641ca5750da)