### PR TITLE
Handle add shortcut outside text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Journey Log is a creative-first checklist that treats tasks as steps in your sto
 - **Contextual wisdom:** Completing a step unlocks a tailored quote based on its mood, category, or priority. Refresh the insight without toggling completion.
 - **Theme + artful mode:** Comfort, Forest, Ocean, Midnight, and High contrast themes adapt typography, gradients, and cards. Toggle “Artful mode” to layer illustrations (automatically disabled for High contrast for accessibility).
 - **Bulk selection and undo:** Select steps independently from completion status, clear selected or completed items, and undo recent deletes within the grace window.
-- **Keyboard-friendly:** Press Enter in the input to add a step, or use Ctrl/Cmd + Enter to add from anywhere. Use Ctrl/Cmd + Shift + C to clear completed steps.
+- **Keyboard-friendly:** Press Enter in the input to add a step, or use Ctrl/Cmd + Enter to add when you’re not typing in another text field. Use Ctrl/Cmd + Shift + C to clear completed steps.
 - **Persistent insights:** Total, active, completed counts and a live progress bar stay in sync with your actions and retain state via localStorage.
 
 ## Technologies

--- a/script.js
+++ b/script.js
@@ -712,10 +712,11 @@ if (typeof document !== 'undefined') {
             const typingInInput = isTypingInInput(activeElement);
 
             if (event.key === 'Enter' && !event.shiftKey) {
-                if (activeElement === taskInput) {
-                    event.preventDefault();
-                    addTaskButton?.click();
+                if (typingInInput && activeElement !== taskInput) {
+                    return;
                 }
+                event.preventDefault();
+                addTaskButton?.click();
                 return;
             }
 

--- a/tests/shortcuts.spec.js
+++ b/tests/shortcuts.spec.js
@@ -29,4 +29,27 @@ test.describe('Keyboard shortcuts', () => {
     await expect(taskListItems).toHaveCount(1);
     await expect(taskTextItems).toHaveText(['Second task']);
   });
+
+  test('Ctrl/Cmd+Enter does not add while typing in other text inputs', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    const taskInput = page.locator('#taskInput');
+    const taskListItems = page.locator('#taskList li');
+
+    await taskInput.click();
+    await taskInput.fill('Primary step');
+    await page.keyboard.press('Control+Enter');
+    await expect(taskListItems).toHaveCount(1);
+
+    const firstItem = taskListItems.first();
+    await firstItem.getByRole('button', { name: /add note/i }).click();
+    const noteInput = firstItem.getByLabel(/add a note for primary step/i);
+
+    await noteInput.click();
+    await noteInput.fill('Typing a note should not submit');
+    await page.keyboard.press('Control+Enter');
+
+    await expect(taskListItems).toHaveCount(1);
+    await expect(taskInput).toHaveValue('');
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent the global `Ctrl/Cmd+Enter` add shortcut from triggering while the user is actively typing in other text inputs (like task notes). 
- Preserve the ability to add a task via the keyboard when focus isn't in a text field or when the main `taskInput` is focused. 
- Keep other shortcut safeguards (e.g. `Ctrl/Cmd+Shift+C` for clearing completed) functioning and avoid regressions in accessibility and focus handling. 

### Description
- Update `handleKeyboardShortcuts` in `script.js` to early-return when `isTypingInInput(activeElement)` is true and the active element is not `taskInput`, otherwise trigger the add action with `addTaskButton?.click()`; this allows `Ctrl/Cmd+Enter` to work from non-text contexts but not while typing in other inputs. 
- Retain the existing guard for `Ctrl/Cmd+Shift+C` so it also ignores the shortcut when typing in other inputs. 
- Add a Playwright integration test in `tests/shortcuts.spec.js` to assert that `Ctrl/Cmd+Enter` does not add a task while typing into a note textarea. 
- Clarify the README `Keyboard-friendly` blurb in `README.md` to reflect the refined behavior. 

### Testing
- Ran the test suite with `npm test`; the run produced `18 passed` and `21 failed`. 
- Many failures are due to Playwright browser binaries not being available in the environment and the runner emitting an instruction to run `npx playwright install`. 
- The updated shortcut test was added to `tests/shortcuts.spec.js` and will execute once Playwright browsers are installed. 
- No additional manual testing was performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5a5ffd38832fa116414fbc3b8336)