### PR TITLE
Add regression test for Clear selected button state

### DIFF
--- a/tests/undo.spec.js
+++ b/tests/undo.spec.js
@@ -30,4 +30,34 @@ test.describe('Undo last delete', () => {
     await expect(taskTexts).toHaveText(['Keep me', 'Remove me']);
     await expect(undoButton).toBeDisabled();
   });
+
+  test('Clear selected button reflects selection state and stays quiet when disabled', async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+
+    const taskInput = page.locator('#taskInput');
+    const addButton = page.getByRole('button', { name: /Add a new journey step/i });
+    const clearSelectedButton = page.getByRole('button', { name: /Clear selected/i });
+    const selectionCheckbox = page.getByTestId('select-checkbox').first();
+    const validationMessage = page.getByTestId('input-validation');
+
+    await expect(clearSelectedButton).toBeDisabled();
+    await expect(validationMessage).toBeHidden();
+
+    await taskInput.fill('Selectable task');
+    await addButton.click();
+
+    await expect(clearSelectedButton).toBeDisabled();
+
+    await selectionCheckbox.check();
+    await expect(clearSelectedButton).toBeEnabled();
+
+    await selectionCheckbox.uncheck();
+    await expect(clearSelectedButton).toBeDisabled();
+
+    await clearSelectedButton.click({ force: true });
+    await expect(clearSelectedButton).toBeDisabled();
+    await expect(validationMessage).toBeHidden();
+    await expect(validationMessage).toBeEmpty();
+  });
 });


### PR DESCRIPTION
### Motivation
- Ensure the bulk action `Clear selected` correctly reflects selection state (disabled when no selections, enabled when items are selected) to prevent accidental user actions.
- Prevent noisy validation feedback when the button is clicked while no items are selected by asserting the UI remains quiet.

### Description
- Added a new Playwright test to `tests/undo.spec.js` that asserts the `Clear selected` button starts disabled, becomes enabled after selecting a task, and becomes disabled again after deselecting.
- The test also performs a regression step that clicks the button with no selections using `click({ force: true })` and verifies the validation region (`data-testid="input-validation"`) stays hidden and empty.
- The test locates controls via `getByRole` and `getByTestId` to exercise selection checkboxes and bulk action controls.

### Testing
- Ran the test suite with `npm test` and confirmed all tests passed (`40 passed`).
- The new spec `tests/undo.spec.js` executed as part of the suite and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d77ad06bc832fb961e9dfe9037e42)