### PR TITLE
Initialize selection actions, relax Ctrl/Cmd+Enter scope, and add selection Playwright test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Journey Log is a creative-first checklist that treats tasks as steps in your sto
 - **Inline micro-journaling:** Add quick notes to any step without leaving the list. Notes autosave and reveal a subtle badge when present.
 - **Creative prompts and milestones:** An empty-state carousel offers spark-ready prompts, while a milestone strip celebrates progress at 5/10/20 completed steps with gentle flares (respecting reduced-motion preferences).
 - **Contextual wisdom:** Completing a step unlocks a tailored quote based on its mood, category, or priority. Refresh the insight without toggling completion.
-- **Theme + artful mode:** Comfort, Forest, Ocean, Midnight, and High contrast themes adapt typography, gradients, and cards. Toggle “Artful mode” to layer illustrations (automatically disabled for High contrast for accessibility).
+- **Theme + artful mode:** Comfort, Forest, Ocean, Midnight, and High contrast themes adapt typography, gradients, and cards. Toggle “Artful mode” to layer illustrations (automatically disabled for high contrast for accessibility).
 - **Bulk selection and undo:** Select steps independently from completion status, clear selected or completed items, and undo recent deletes within the grace window.
 - **Keyboard-friendly:** Press Enter in the input to add a step, or use Ctrl/Cmd + Enter to add when you’re not typing in another text field. Use Ctrl/Cmd + Shift + C to clear completed steps.
 - **Persistent insights:** Total, active, completed counts and a live progress bar stay in sync with your actions and retain state via localStorage.

--- a/script.js
+++ b/script.js
@@ -199,6 +199,8 @@ if (typeof document !== 'undefined') {
             ? window.matchMedia('(prefers-reduced-motion: reduce)')
             : { matches: false };
 
+        updateSelectionActions();
+
         const helperBubbleKey = 'journeySeenAddHelper';
         const wisdomToggleKey = 'journeyWisdomEnabled';
         const milestoneKey = 'journeyMilestone';
@@ -693,7 +695,7 @@ if (typeof document !== 'undefined') {
         function isTypingInInput(element) {
             if (!element) return false;
             const tagName = element.tagName;
-            if (tagName === 'TEXTAREA' || tagName === 'SELECT') {
+            if (tagName === 'TEXTAREA') {
                 return true;
             }
 

--- a/tests/selection-actions.spec.js
+++ b/tests/selection-actions.spec.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Clear selected button state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload({ waitUntil: 'domcontentloaded' });
+  });
+
+  test('stays disabled until a selection exists and re-disables when cleared', async ({ page }) => {
+    const clearSelectedButton = page.locator('#clearSelectedButton');
+    await expect(clearSelectedButton).toBeDisabled();
+
+    const taskInput = page.locator('#taskInput');
+    const addTaskButton = page.getByRole('button', { name: /Add Step/i });
+
+    await taskInput.fill('Selectable task');
+    await addTaskButton.click();
+
+    await expect(clearSelectedButton).toBeDisabled();
+
+    const selectCheckbox = page.getByTestId('select-checkbox').first();
+    await selectCheckbox.check();
+    await expect(clearSelectedButton).toBeEnabled();
+
+    await selectCheckbox.uncheck();
+    await expect(clearSelectedButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Keep UI copy consistent by aligning README wording for the high contrast theme.
- Fix a selection UX bug where the `Clear selected` button could be out of sync and not start disabled when nothing is selected.
- Make the `Ctrl/Cmd+Enter` add shortcut work in more contexts (beyond the main text input) to match expected behavior.
- Prevent regressions by adding automated coverage for the selection control behavior.

### Description
- Update `README.md` to use the `high contrast` phrasing for consistency with the UI.
- Ensure `updateSelectionActions()` is invoked during initialization and after renders so `#clearSelectedButton` stays disabled until at least one task is selected.
- Change `isTypingInInput` to stop treating `SELECT` elements as text inputs so keyboard shortcut handling allows `Ctrl/Cmd+Enter` when a select is focused.
- Add a Playwright test `tests/selection-actions.spec.js` that verifies the enabled/disabled state of `#clearSelectedButton` as tasks are added and selection changes.

### Testing
- Ran `npm test` which launches the Playwright suite; the runner executed tests but the environment lacks browser binaries so the full suite could not complete.
- The test run showed many unit tests executed (several passed) but the Playwright runner failed with an error indicating browsers must be installed via `npx playwright install` to reproduce a full green run.
- The newly added `selection-actions.spec.js` is included in the suite and will validate the `Clear selected` behavior when run in an environment with Playwright browsers installed.
- No other test failures were introduced by these code changes in the local assertions that executed prior to the environment limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2ec2adf4832f99dae9a96c733ec2)