### PR TITLE
Fix initial selection handling and align license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
     "@playwright/test": "^1.57.0"

--- a/script.js
+++ b/script.js
@@ -199,8 +199,6 @@ if (typeof document !== 'undefined') {
             ? window.matchMedia('(prefers-reduced-motion: reduce)')
             : { matches: false };
 
-        updateSelectionActions();
-
         const helperBubbleKey = 'journeySeenAddHelper';
         const wisdomToggleKey = 'journeyWisdomEnabled';
         const milestoneKey = 'journeyMilestone';
@@ -298,6 +296,7 @@ if (typeof document !== 'undefined') {
         const prefersReducedMotion = prefersReducedMotionQuery.matches;
         const saveFeedback = createSaveFeedbackController(saveStatus);
         updateUndoButtonState(false);
+        updateSelectionActions();
 
         initializeHelperBubble();
         renderTasks();


### PR DESCRIPTION
### Motivation
- Prevent a startup timing issue where selection-related UI helpers could run before tasks are loaded, causing incorrect initial state or early DOM/logic access.
- Keep repository metadata consistent by aligning `package.json` license with the MIT license declared in the README and LICENSE file.

### Description
- Move the initial `updateSelectionActions()` call so it runs after task state and save-feedback are initialized to avoid early-selection references during startup (`script.js`).
- Change the project license field from `ISC` to `MIT` in `package.json` to match the repository README and `LICENSE` file.

### Testing
- No automated tests were run against these changes (Playwright test suite accessible via `npm test` was not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b8ed074a0832f89a21ac9ae28e607)