### PR TITLE
Add Prettier format script and guard select-all state (with regression test)

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -279,6 +279,9 @@ test.describe('computeInsights and getSelectAllState', () => {
     });
 
     test('derives select-all state', () => {
+        const initial = getSelectAllState();
+        expect(initial).toEqual({ checked: false, indeterminate: false });
+
         const unselected = getSelectAllState([
             { id: 1, selected: false },
             { id: 2, selected: false }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,10 @@
     "": {
       "name": "journey-log",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
-        "@playwright/test": "^1.57.0"
+        "@playwright/test": "^1.57.0",
+        "prettier": "^3.3.3"
       }
     },
     "node_modules/@playwright/test": {
@@ -73,6 +74,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "description": "This repository captures the evolution from an early LLM-generated prototype to the current workflow powered by OpenAI Codex. It shows how iterative prompts and code refinement can steadily improve a simple idea.",
   "main": "script.js",
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "format": "prettier --check ."
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.57.0"
+    "@playwright/test": "^1.57.0",
+    "prettier": "^3.3.3"
   }
 }

--- a/script.js
+++ b/script.js
@@ -42,6 +42,9 @@ function toggleAllTasks(tasks, shouldComplete) {
 }
 
 function getSelectAllState(tasks) {
+    if (!Array.isArray(tasks)) {
+        return { checked: false, indeterminate: false };
+    }
     const totalTasks = tasks.length;
     if (totalTasks === 0) {
         return { checked: false, indeterminate: false };


### PR DESCRIPTION
### Motivation
- Prevent startup errors when selection state is derived before tasks are loaded by ensuring the select-all helper tolerates missing/invalid task data.
- Add a lightweight formatting check to the project to make future edits consistent and easier to review.

### Description
- Added a defensive guard to `getSelectAllState` to return `{ checked: false, indeterminate: false }` when `tasks` is not an array to avoid referencing task state during initialization (`script.js`).
- Added a regression test that calls `getSelectAllState()` with no arguments and asserts the default `{ checked: false, indeterminate: false }` (`__tests__/script.test.js`).
- Added a `format` script to `package.json` (`"format": "prettier --check ."`) and added `prettier` as a devDependency, with `package-lock.json` updated accordingly.

### Testing
- Installed the formatter dev dependency with `npm install --save-dev prettier@3.3.3`, which completed successfully.
- No automated test runner (Playwright tests) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b91f4c2b8832f96bebde32de4ea93)