### PR TITLE
Fix milestone focus selection

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -7,6 +7,7 @@ const {
     restoreDeletedTasks,
     getSelectAllState,
     deriveMilestoneState,
+    getCompletedTaskForMilestone,
     updateTaskNote,
     getNextOpenNoteId,
     pickQuoteForTask
@@ -380,6 +381,30 @@ test.describe('milestones and wisdom', () => {
         const quote = pickQuoteForTask(task, wisdomSet);
 
         expect(['Hello', 'High']).toContain(quote.text);
+    });
+
+    test('selects the milestone completion task by index', () => {
+        const tasks = [
+            { id: 1, completed: true },
+            { id: 2, completed: true },
+            { id: 3, completed: false },
+            { id: 4, completed: true },
+            { id: 5, completed: true },
+            { id: 6, completed: true }
+        ];
+
+        expect(getCompletedTaskForMilestone(tasks, 3)).toEqual({ id: 4, completed: true });
+        expect(getCompletedTaskForMilestone(tasks, 5)).toEqual({ id: 6, completed: true });
+    });
+
+    test('falls back to the most recent completed task when milestone exceeds count', () => {
+        const tasks = [
+            { id: 10, completed: true },
+            { id: 11, completed: false },
+            { id: 12, completed: true }
+        ];
+
+        expect(getCompletedTaskForMilestone(tasks, 5)).toEqual({ id: 12, completed: true });
     });
 
     test('avoids repeating the same quote when alternative exists', () => {

--- a/script.js
+++ b/script.js
@@ -126,6 +126,20 @@ function deriveMilestoneState(completedCount, thresholds) {
     return { unlocked, next, lastUnlocked };
 }
 
+function getCompletedTaskForMilestone(tasks, milestoneValue) {
+    if (!Array.isArray(tasks)) return null;
+    const completedTasks = tasks
+        .filter(task => task.completed)
+        .sort((a, b) => a.id - b.id);
+    if (completedTasks.length === 0) return null;
+    const milestoneCount = Number(milestoneValue);
+    if (!Number.isFinite(milestoneCount) || milestoneCount <= 0) {
+        return completedTasks[completedTasks.length - 1];
+    }
+    const targetIndex = Math.min(milestoneCount, completedTasks.length) - 1;
+    return completedTasks[targetIndex];
+}
+
 function updateTaskNote(tasks, taskId, noteText) {
     return tasks.map(task => task.id === taskId ? { ...task, note: noteText } : task);
 }
@@ -1055,8 +1069,7 @@ if (typeof document !== 'undefined') {
         }
 
         function handleTaskFocusFromMilestone(value) {
-            const completedTasks = tasks.filter(t => t.completed).sort((a, b) => b.id - a.id);
-            const task = completedTasks[0];
+            const task = getCompletedTaskForMilestone(tasks, value);
             if (task) {
                 displayWisdomForTask(task);
             }
@@ -1192,6 +1205,7 @@ if (typeof module !== 'undefined') {
         createSaveFeedbackController,
         restoreDeletedTasks,
         deriveMilestoneState,
+        getCompletedTaskForMilestone,
         updateTaskNote,
         getNextOpenNoteId,
         pickQuoteForTask


### PR DESCRIPTION
### Motivation
- Milestone markers always showed the most recently completed task instead of mapping to the clicked milestone value, causing milestone clicks to be misleading. 
- The intended UX chosen here is to map a milestone to the Nth completed task (the task that caused reaching that milestone) and fall back to the most recent completed task when there are fewer completed tasks than the milestone value.

### Description
- Add `getCompletedTaskForMilestone(tasks, milestoneValue)` to compute the milestone-associated completed task by selecting the Nth completed task (ordered by `id`) and falling back to the last completed task when needed. 
- Update `handleTaskFocusFromMilestone` to call `getCompletedTaskForMilestone` and display wisdom for the resolved task. 
- Export `getCompletedTaskForMilestone` from `module.exports` so it can be tested. 
- Add unit tests in `__tests__/script.test.js` covering selection by index and fallback behavior.

### Testing
- Ran `npx playwright test __tests__/script.test.js` and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974edf8f2d4832fb4b635b65f467240)