### PR TITLE
Remove unused toggleAllTasks helper and export

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,10 +37,6 @@ function updateWisdomVisibility(tasks, showWisdom, hideWisdom, options = {}) {
     return hasCompletedTasks;
 }
 
-function toggleAllTasks(tasks, shouldComplete) {
-    return tasks.map(task => ({ ...task, completed: shouldComplete }));
-}
-
 function getSelectAllState(tasks) {
     if (!Array.isArray(tasks)) {
         return { checked: false, indeterminate: false };
@@ -1200,7 +1196,6 @@ if (typeof module !== 'undefined') {
         computeInsights,
         updateInsights,
         updateWisdomVisibility,
-        toggleAllTasks,
         getSelectAllState,
         createSaveFeedbackController,
         restoreDeletedTasks,


### PR DESCRIPTION
### Motivation
- Remove dead design-debt abstraction `toggleAllTasks` to simplify the code surface and reduce exports; confirmed it was unused in the codebase and test files.

### Description
- Delete the `toggleAllTasks(tasks, shouldComplete)` helper and remove it from the `module.exports` list in `script.js`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f2068578832f9a2f8e0930cb3ab1)