### PR TITLE
Stop prompt carousel when tasks exist

### DIFF
--- a/script.js
+++ b/script.js
@@ -320,7 +320,6 @@ if (typeof document !== 'undefined') {
         revealInputSection();
         applyTheme(localStorage.getItem('journeyTheme'));
         syncArtfulMode();
-        startPromptCarousel();
 
         themeSelect?.addEventListener('change', (event) => applyTheme(event.target.value));
         artfulModeToggle?.addEventListener('change', handleArtfulToggle);
@@ -445,6 +444,7 @@ if (typeof document !== 'undefined') {
                 starterHint.classList.add('hidden');
             }
             setPromptForEmptyState();
+            startPromptCarousel();
 
             tasks.forEach(task => {
                 const listItem = document.createElement('li');
@@ -1126,10 +1126,14 @@ if (typeof document !== 'undefined') {
 
         function startPromptCarousel() {
             if (!carouselPrompt) return;
-            renderCarouselPrompt();
             if (carouselTimer) {
                 clearInterval(carouselTimer);
+                carouselTimer = null;
             }
+            if (tasks.length !== 0) {
+                return;
+            }
+            renderCarouselPrompt();
             carouselTimer = setInterval(() => {
                 if (tasks.length === 0) {
                     shuffleCarouselPrompt();


### PR DESCRIPTION
### Motivation

- Avoid wasting CPU cycles by preventing the prompt carousel `setInterval` from running when there are tasks in the list.

### Description

- Modified `startPromptCarousel` in `script.js` to clear any existing timer and only schedule the interval when `tasks.length === 0` by returning early when tasks exist.
- Ensure existing timers are fully cleared by setting `carouselTimer = null` when clearing the interval. 
- Move the call to `startPromptCarousel()` into `renderTasks()` (after `setPromptForEmptyState()`) so the carousel is stopped or restarted whenever the task list is re-rendered.
- Removed the unconditional initial `startPromptCarousel()` call at DOMContentLoaded to avoid scheduling the interval when tasks are already present on load.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f4777170832fa7dcc413bed8c6ff)