### PR TITLE
Fix wisdom refresh exclusion so `forceRefresh` avoids repeating last quote

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -10,7 +10,8 @@ const {
     getCompletedTaskForMilestone,
     updateTaskNote,
     getNextOpenNoteId,
-    pickQuoteForTask
+    pickQuoteForTask,
+    resolveWisdomExcludeText
 } = require('../script.js');
 
 function createSpy() {
@@ -420,5 +421,38 @@ test.describe('milestones and wisdom', () => {
         const second = pickQuoteForTask(task, wisdomSet, { excludeText: first.text });
 
         expect(second.text).not.toBe(first.text);
+    });
+
+    test('respects force refresh exclusion when available', () => {
+        const task = { mood: 'bright', category: '', priority: '' };
+        const wisdomSet = {
+            mood: { bright: [{ text: 'First', author: 'Test' }, { text: 'Second', author: 'Test' }] },
+            category: {},
+            priority: {},
+            fallback: []
+        };
+
+        const excludeText = resolveWisdomExcludeText('First', true);
+        const quote = pickQuoteForTask(task, wisdomSet, { excludeText });
+
+        expect(quote.text).toBe('Second');
+    });
+
+    test('does not exclude previous quote without force refresh', () => {
+        const task = { mood: 'bright', category: '', priority: '' };
+        const wisdomSet = {
+            mood: { bright: [{ text: 'First', author: 'Test' }, { text: 'Second', author: 'Test' }] },
+            category: {},
+            priority: {},
+            fallback: []
+        };
+
+        const originalRandom = Math.random;
+        Math.random = () => 0;
+        const excludeText = resolveWisdomExcludeText('First', false);
+        const quote = pickQuoteForTask(task, wisdomSet, { excludeText });
+        Math.random = originalRandom;
+
+        expect(quote.text).toBe('First');
     });
 });

--- a/script.js
+++ b/script.js
@@ -170,6 +170,13 @@ function pickQuoteForTask(task, wisdomSet, options = {}) {
     return available[randomIndex];
 }
 
+function resolveWisdomExcludeText(lastQuoteText, forceRefresh) {
+    if (!forceRefresh) {
+        return undefined;
+    }
+    return lastQuoteText || undefined;
+}
+
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
         const clearCompletedButton = document.getElementById('clearCompletedButton');
@@ -1090,7 +1097,7 @@ if (typeof document !== 'undefined') {
                 return;
             }
             activeWisdomTaskId = task.id;
-            const excludeText = options.forceRefresh ? lastWisdomQuoteText : lastWisdomQuoteText;
+            const excludeText = resolveWisdomExcludeText(lastWisdomQuoteText, options.forceRefresh);
             const quote = pickQuoteForTask(task, wisdomQuotes, { excludeText }) || pickQuoteForTask({}, wisdomQuotes, { excludeText });
             if (!quote) return;
             renderWisdomText(quote, options.forceRefresh);
@@ -1207,6 +1214,7 @@ if (typeof module !== 'undefined') {
         getCompletedTaskForMilestone,
         updateTaskNote,
         getNextOpenNoteId,
-        pickQuoteForTask
+        pickQuoteForTask,
+        resolveWisdomExcludeText
     };
 }


### PR DESCRIPTION
### Motivation

- The wisdom refresh logic previously treated the previous quote the same regardless of `forceRefresh`, making the refresh button ineffective at avoiding repeats.
- The intended behavior is that when `forceRefresh` is true, the selector should try to pick a different quote if one exists.

### Description

- Add `resolveWisdomExcludeText(lastQuoteText, forceRefresh)` to return an exclusion only when `forceRefresh` is true and a previous quote exists. 
- Use the helper in `displayWisdomForTask` so `pickQuoteForTask` receives an `excludeText` only on force refresh attempts. 
- Export the new helper and wire it into the module exports. 
- Add unit tests in `__tests__/script.test.js` that assert the new behavior for force-refresh exclusion and that no exclusion is applied when `forceRefresh` is false. 
- Files changed: `script.js`, `__tests__/script.test.js`.

### Testing

- Ran the test suite via `npm test` (Playwright test runner); the unit tests in `__tests__/script.test.js` passed, including the two new tests covering force-refresh exclusion. 
- The full Playwright suite could not complete because browser binaries are missing in the environment (Playwright errors recommending `npx playwright install`), causing other browser-driven tests to fail; the wisdom-related unit tests still succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f5de0db0832fb53ad04c9410d119)