### PR TITLE
Add Playwright test for corrupted localStorage recovery

### DIFF
--- a/tests/storage-recovery.spec.js
+++ b/tests/storage-recovery.spec.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Storage recovery', () => {
+  test('clears corrupted task data and renders empty state', async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+    await page.evaluate(() => {
+      localStorage.setItem('journeyTasks', '{this is not valid json');
+    });
+
+    await page.reload();
+
+    await expect(page.locator('#taskList li')).toHaveCount(0);
+    await expect(page.locator('#emptyState')).toBeVisible();
+
+    const storedTasks = await page.evaluate(() => localStorage.getItem('journeyTasks'));
+    expect(storedTasks).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure corrupted `journeyTasks` data in `localStorage` is detected and cleared so the app recovers cleanly to the empty state on reload.

### Description
- Add `tests/storage-recovery.spec.js` with a Playwright test that seeds invalid JSON into `localStorage.journeyTasks`, reloads the app, asserts no tasks are rendered (`#taskList li` count is 0), verifies `#emptyState` is visible, and confirms `localStorage.getItem('journeyTasks')` is `null`.

### Testing
- No automated tests were run for this change; run `npm test` to execute the Playwright test suite (`playwright test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f72da84c832fbba62072a6d63ee3)