### PR TITLE
Add Playwright test for undo timeout behavior

### DIFF
--- a/tests/undo.spec.js
+++ b/tests/undo.spec.js
@@ -60,4 +60,26 @@ test.describe('Undo last delete', () => {
     await expect(validationMessage).toBeHidden();
     await expect(validationMessage).toBeEmpty();
   });
+
+  test('clears undo buffer and hides undo button after timeout', async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+
+    const taskInput = page.locator('#taskInput');
+    const addButton = page.getByRole('button', { name: /Add a new journey step/i });
+    const undoButton = page.locator('#undoDeleteButton');
+
+    await taskInput.fill('Time-sensitive task');
+    await addButton.click();
+
+    const deleteButton = page.locator('li', { hasText: 'Time-sensitive task' }).getByRole('button', { name: /Delete/i });
+    await deleteButton.click();
+
+    await expect(undoButton).toBeEnabled();
+
+    await page.waitForTimeout(8000);
+
+    await expect(undoButton).toBeDisabled();
+    await expect(undoButton).toBeHidden();
+  });
 });


### PR DESCRIPTION
### Motivation
- Validate that the undo buffer is cleared and the undo UI is hidden/disabled after the configured timeout (`8000` ms) so the UI behavior matches the code path in `script.js`.

### Description
- Add a Playwright test in `tests/undo.spec.js` that creates a task, deletes it, asserts the undo button is enabled, waits `8000` ms, and then asserts the `#undoDeleteButton` is disabled and hidden.

### Testing
- No automated tests were run locally or in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f87974d4832fa47b99382df48563)