### PR TITLE
Use collision-resistant task IDs, fix aria-label, and add milestone test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A browser-based checklist that stores steps in localStorage, adds optional mood/
 ## Testing
 
 - Run Playwright tests with `npm test`.
+- Note: Playwright defaults to the `tests/` directory, so the unit-style specs in `__tests__/` are not picked up unless you move them under `tests/` or add a Playwright config that points at `__tests__/` instead.
 
 ## Credits
 

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -408,6 +408,18 @@ test.describe('milestones and wisdom', () => {
         expect(getCompletedTaskForMilestone(tasks, 5)).toEqual({ id: 12, completed: true });
     });
 
+    test('falls back to the most recent completed task when milestone value is invalid', () => {
+        const tasks = [
+            { id: 20, completed: true },
+            { id: 21, completed: false },
+            { id: 22, completed: true }
+        ];
+
+        expect(getCompletedTaskForMilestone(tasks, 0)).toEqual({ id: 22, completed: true });
+        expect(getCompletedTaskForMilestone(tasks, NaN)).toEqual({ id: 22, completed: true });
+        expect(getCompletedTaskForMilestone(tasks, 'not-a-number')).toEqual({ id: 22, completed: true });
+    });
+
     test('avoids repeating the same quote when alternative exists', () => {
         const task = { mood: 'bright', category: '', priority: '' };
         const wisdomSet = {

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                 <div id="inputValidation" data-testid="input-validation" class="input-validation hidden" role="status" aria-live="polite" aria-hidden="true"></div>
                 <div id="saveStatus" class="save-status" role="status" aria-live="polite" aria-hidden="true"></div>
             </div>
-            <button id="secondaryAddButton" class="secondary-add" type="button" aria-label="Add a journey step (mobile friendly)">Add</button>
+            <button id="secondaryAddButton" class="secondary-add" type="button" aria-label="Add a journey step (mobile-friendly)">Add</button>
 
         </div>
 

--- a/script.js
+++ b/script.js
@@ -177,6 +177,20 @@ function resolveWisdomExcludeText(lastQuoteText, forceRefresh) {
     return lastQuoteText || undefined;
 }
 
+let lastTaskIdTimestamp = 0;
+let taskIdSequence = 0;
+
+function createTaskId() {
+    const now = Date.now();
+    if (now === lastTaskIdTimestamp) {
+        taskIdSequence += 1;
+    } else {
+        lastTaskIdTimestamp = now;
+        taskIdSequence = 0;
+    }
+    return (now * 1000) + taskIdSequence;
+}
+
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
         const clearCompletedButton = document.getElementById('clearCompletedButton');
@@ -398,7 +412,7 @@ if (typeof document !== 'undefined') {
 
         function addTask(description, meta = {}) {
             const task = {
-                id: Date.now(),
+                id: createTaskId(),
                 description: description,
                 completed: false,
                 selected: false,


### PR DESCRIPTION
### Motivation

- Prevent duplicate task IDs when tasks are added rapidly by replacing `Date.now()`-based IDs with a collision-resistant generator. 
- Improve copy consistency by hyphenating the secondary add button aria-label to `mobile-friendly`.
- Make documentation accurate about Playwright test discovery so contributors know where Playwright looks for specs.
- Increase test coverage for `getCompletedTaskForMilestone` fallback behavior on invalid milestone input.

### Description

- Replaced `Date.now()` with a numeric generator `createTaskId()` that combines the current timestamp with a per-timestamp sequence to avoid collisions when multiple IDs are created in the same millisecond (`script.js`).
- Hyphenated the secondary add button aria-label from `Add a journey step (mobile friendly)` to `Add a journey step (mobile-friendly)` (`index.html`).
- Updated `README.md` Testing section to note that Playwright defaults to the `tests/` directory and that specs in `__tests__/` are not discovered unless moved or configured.
- Added a unit test to `__tests__/script.test.js` that verifies `getCompletedTaskForMilestone` falls back to the most recent completed task when `milestoneValue` is invalid (e.g., `0`, `NaN`, or non-numeric).

### Testing

- No automated tests were executed as part of this change.
- A new unit test was added at `__tests__/script.test.js` covering invalid milestone values; it should be run by the project’s test runner when configured to include `__tests__/` or after moving the spec under `tests/` or adjusting Playwright config.
- Documentation was updated to instruct running Playwright with `npm test` and to explain test discovery behavior for `__tests__/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f677b7e8832fa2e4ee6a5a10d747)