### PR TITLE
Add Playwright config to include both tests/ and __tests__

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ A browser-based checklist that stores steps in localStorage, adds optional mood/
 
 ## Testing
 
-- Run Playwright tests with `npm test`.
-- Note: Playwright defaults to the `tests/` directory, so the unit-style specs in `__tests__/` are not picked up unless you move them under `tests/` or add a Playwright config that points at `__tests__/` instead.
+- Run all automated tests with `npm test`.
 
 ## Credits
 

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,6 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.js', '__tests__/**/*.test.js'],
+});


### PR DESCRIPTION
### Motivation

- Ensure a single Playwright run picks up both the browser-style specs in `tests/**/*.spec.js` and the unit-style specs in `__tests__/**/*.test.js` so contributors can run all tests with one command.

### Description

- Add a root Playwright config file `playwright.config.cjs` that sets `testDir: '.'` and `testMatch: ['tests/**/*.spec.js', '__tests__/**/*.test.js']` to include both suites.
- Update the README `Testing` section to document a single canonical command `npm test` and remove the prior caveat about missing `__tests__/` coverage.
- Leave the `package.json` `test` script unchanged since it already runs `playwright test` and will pick up the new root config automatically.

### Testing

- Ran `npm test`; Playwright discovered tests from both `tests/` and `__tests__/` and began executing 48 tests in total.
- The run showed 23 tests passed and 25 tests failed because Playwright browser binaries are not installed in this environment, producing the instructive error that `npx playwright install` is required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699accea0754832fa82f1720c98546b6)