### PR TITLE
Debounce note saves and update note UI in place

### DIFF
--- a/tests/note-input.spec.js
+++ b/tests/note-input.spec.js
@@ -1,0 +1,83 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('Note input behavior', () => {
+  test('updates note UI immediately without replacing the note input element', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    const taskInput = page.locator('#taskInput');
+    const taskListItems = page.locator('#taskList li');
+
+    await taskInput.fill('Primary step');
+    await page.keyboard.press('Control+Enter');
+    await expect(taskListItems).toHaveCount(1);
+
+    const firstItem = taskListItems.first();
+    const noteToggle = firstItem.getByRole('button', { name: /add note for primary step/i });
+
+    await noteToggle.click();
+
+    const noteInput = firstItem.getByLabel(/add a note for primary step/i);
+    const noteInputHandle = await noteInput.elementHandle();
+
+    await noteInput.fill('A quick thought');
+
+    await expect(firstItem.getByRole('button', { name: /edit note for primary step/i })).toHaveText('Note added');
+    await expect(firstItem.locator('.badge-note')).toHaveCount(1);
+    await expect(firstItem.locator('[data-control="note-toggle"]')).toHaveAttribute('aria-expanded', 'true');
+
+    const sameElement = await page.evaluate((element) => {
+      return element === document.querySelector('li[data-task-id] [data-control="note-input"]');
+    }, noteInputHandle);
+
+    expect(sameElement).toBe(true);
+
+    await noteInput.fill('');
+
+    await expect(firstItem.getByRole('button', { name: /add note for primary step/i })).toHaveText('Add note');
+    await expect(firstItem.locator('.badge-note')).toHaveCount(0);
+    await expect(firstItem.locator('[data-control="note-toggle"]')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('persists note content with debounce and flushes on blur', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    const taskInput = page.locator('#taskInput');
+    const taskListItems = page.locator('#taskList li');
+
+    await taskInput.fill('Debounced note task');
+    await page.keyboard.press('Control+Enter');
+    await expect(taskListItems).toHaveCount(1);
+
+    const firstItem = taskListItems.first();
+    await firstItem.getByRole('button', { name: /add note/i }).click();
+    const noteInput = firstItem.getByLabel(/add a note for debounced note task/i);
+
+    await noteInput.fill('draft');
+
+    const immediateNote = await page.evaluate(() => {
+      const tasks = JSON.parse(localStorage.getItem('journeyTasks') || '[]');
+      return tasks[0]?.note ?? '';
+    });
+    expect(immediateNote).toBe('');
+
+    await page.waitForTimeout(320);
+
+    const persistedAfterDebounce = await page.evaluate(() => {
+      const tasks = JSON.parse(localStorage.getItem('journeyTasks') || '[]');
+      return tasks[0]?.note ?? '';
+    });
+    expect(persistedAfterDebounce).toBe('draft');
+
+    await noteInput.fill('blur-save');
+    await noteInput.blur();
+
+    const persistedOnBlur = await page.evaluate(() => {
+      const tasks = JSON.parse(localStorage.getItem('journeyTasks') || '[]');
+      return tasks[0]?.note ?? '';
+    });
+    expect(persistedOnBlur).toBe('blur-save');
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve typing responsiveness by avoiding full task list rerenders on every note keystroke while keeping UI and accessibility attributes synchronized.
- Persist note edits reliably but not too eagerly by batching storage writes with a short debounce per task.
- Ensure pending note saves are cleaned up when tasks are deleted or cleared to avoid stale timers.

### Description
- Introduced a per-task debouncer `createPerTaskDebouncer` and wired it into note handling so note saves are scheduled per task with a 250ms default delay and can be flushed or cancelled. 
- Refactored `handleNoteInput` to update the in-memory task immediately and call a new `updateTaskNoteUI` helper to update only note-related DOM (badge, toggle text/class, and `aria-*` attributes) instead of calling `renderTasks` on every input. 
- Added `blur` handling to flush pending note saves (`flushTaskNoteSave`) and cancel/flush helpers used when deleting or clearing tasks. 
- Exported the new debouncer for tests and added/updated tests: a unit suite for the per-task debouncer and a Playwright browser spec covering note typing UI, debounce persistence, and blur flush behavior.

### Testing
- Unit tests in `__tests__/script.test.js` (including new per-task debounce tests) were run and passed (`npx playwright test __tests__/script.test.js` — 25/25 passed). 
- New browser tests in `tests/note-input.spec.js` were added and run locally with Playwright, but they failed in this execution environment due to missing or incompatible Chromium runtime system libraries (Playwright reported missing executable / shared libs like `libatk-1.0.so.0`), resulting in 2 failing E2E tests when run together with the unit suite. 
- The change set and tests are committed and ready; browser E2E tests should pass in CI or developer environments with Playwright browsers and required system libraries installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad10c5ec8832fa2d91ec6e52cb8ca)