### PR TITLE
Use keydown with IME-safe Enter handling for task input

### DIFF
--- a/script.js
+++ b/script.js
@@ -471,11 +471,13 @@ if (typeof document !== 'undefined') {
             taskInput?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         });
 
-        taskInput?.addEventListener('keypress', (event) => {
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                handleAddFromInput();
+        taskInput?.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter' || event.isComposing) {
+                return;
             }
+
+            event.preventDefault();
+            handleAddFromInput();
         });
 
         shufflePrompt?.addEventListener('click', shuffleCarouselPrompt);


### PR DESCRIPTION
### Motivation
- Replace the `keypress` listener with `keydown` and add an IME/composition guard so Enter submissions behave correctly when using input methods and to align with modern keyboard event handling.

### Description
- Replaced `taskInput?.addEventListener('keypress', ...)` with `taskInput?.addEventListener('keydown', ...)` and only submit when `event.key === 'Enter'` and `event.isComposing` is false, then call `event.preventDefault()` and `handleAddFromInput()`; global `Ctrl/Cmd+Enter` shortcut logic in `handleKeyboardShortcuts` was left unchanged.

### Testing
- Ran the keyboard-related Playwright specs with `npm test -- tests/shortcuts.spec.js tests/save-indicator.spec.js`, but the test run could not complete due to missing Chromium runtime dependencies (`libatk-1.0.so.0`); `npx playwright install chromium` was attempted but the environment still prevented executing the browser tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad28d51e4832f8e9f6d6f2a3b1a77)