### PR TITLE
Add PWA manifest, service worker, install docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ A browser-based checklist that stores steps in localStorage, adds optional mood/
 - **Add a note:** Click **Add note** on a step and type a quick reflection; the note saves immediately.
 - **Keyboard shortcut:** Press Ctrl/Cmd + Enter to add a step when focus isn’t in another text field.
 
+## Install on iOS/Android
+
+You can add The Journey Log to your home screen so it opens like an app:
+
+- **Android (Chrome/Edge):** Open the site, tap the browser menu (`⋮`), then choose **Install app** or **Add to Home screen**.
+- **iPhone/iPad (Safari):** Open the site, tap **Share** (`⬆`), then choose **Add to Home Screen**.
+- After installing, launch it from your home screen/app drawer for a full-screen app experience.
+
 ## Testing
 
 - Run all automated tests with `npm test`.

--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-label="Journey Log icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5f4bb6" />
+      <stop offset="100%" stop-color="#8f7cff" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="38" fill="url(#bg)" />
+  <path d="M48 56h96v16H48zm0 32h96v16H48zm0 32h64v16H48z" fill="#fff"/>
+  <circle cx="132" cy="128" r="12" fill="#d6f3ff"/>
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Journey Log icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5f4bb6" />
+      <stop offset="100%" stop-color="#8f7cff" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="104" fill="url(#bg)" />
+  <path d="M128 154h256v42H128zm0 84h256v42H128zm0 84h170v42H128z" fill="#fff"/>
+  <circle cx="352" cy="342" r="34" fill="#d6f3ff"/>
+</svg>

--- a/icons/icon-maskable.svg
+++ b/icons/icon-maskable.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Journey Log maskable icon">
+  <rect width="512" height="512" fill="#4f3fa0" />
+  <rect x="52" y="52" width="408" height="408" rx="96" fill="#7f6cff" />
+  <path d="M146 174h220v40H146zm0 80h220v40H146zm0 80h146v40H146z" fill="#fff"/>
+  <circle cx="338" cy="354" r="30" fill="#d6f3ff"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,18 @@
     <meta charset="UTF-8">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#5f4bb6">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-title" content="Journey Log">
 
     <title>The Journey Log</title>
 
+    <link rel="manifest" href="manifest.webmanifest">
+    <link rel="icon" href="icons/icon-192.svg" type="image/svg+xml" sizes="192x192">
+    <link rel="icon" href="icons/icon-512.svg" type="image/svg+xml" sizes="512x512">
+    <link rel="apple-touch-icon" href="icons/icon-192.svg">
+    <link rel="mask-icon" href="icons/icon-maskable.svg" color="#5f4bb6">
     <link rel="stylesheet" href="style.css">
 
 </head>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,30 @@
+{
+  "name": "The Journey Log",
+  "short_name": "Journey Log",
+  "description": "Track daily steps with mood-aware insights and milestones.",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#f5f6fb",
+  "theme_color": "#5f4bb6",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-maskable.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -232,6 +232,18 @@ function createTaskId() {
 
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js')
+                .then(() => {
+                    document.documentElement.setAttribute('data-sw-status', 'registered');
+                })
+                .catch(() => {
+                    document.documentElement.setAttribute('data-sw-status', 'failed');
+                });
+        } else {
+            document.documentElement.setAttribute('data-sw-status', 'unsupported');
+        }
+
         const clearCompletedButton = document.getElementById('clearCompletedButton');
         const clearSelectedButton = document.getElementById('clearSelectedButton');
         const undoDeleteButton = document.getElementById('undoDeleteButton');

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,49 @@
+const CACHE_VERSION = 'journey-log-shell-v1';
+const APP_SHELL_FILES = ['index.html', 'style.css', 'script.js'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then(cache => cache.addAll(APP_SHELL_FILES))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys
+          .filter(key => key !== CACHE_VERSION)
+          .map(key => caches.delete(key))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+  const isSameOrigin = requestUrl.origin === self.location.origin;
+  const pathname = requestUrl.pathname.split('/').pop();
+  const isAppShellRequest = APP_SHELL_FILES.includes(pathname);
+
+  if (!isSameOrigin || !isAppShellRequest) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(cachedResponse => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+      return fetch(event.request).then(networkResponse => {
+        const responseClone = networkResponse.clone();
+        caches.open(CACHE_VERSION).then(cache => cache.put(event.request, responseClone));
+        return networkResponse;
+      });
+    })
+  );
+});

--- a/tests/pwa.spec.js
+++ b/tests/pwa.spec.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
+
+test.describe('PWA wiring', () => {
+  test('includes manifest and install icon links', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    await expect(page.locator('link[rel="manifest"][href="manifest.webmanifest"]')).toHaveCount(1);
+    await expect(page.locator('link[rel="apple-touch-icon"][href="icons/icon-192.svg"]')).toHaveCount(1);
+    await expect(page.locator('link[rel="mask-icon"][href="icons/icon-maskable.svg"]')).toHaveCount(1);
+  });
+
+  test('signals service-worker registration in supported contexts', async ({ page }) => {
+    await page.goto(indexFileUrl);
+
+    const supportsRegistration = await page.evaluate(
+      () => 'serviceWorker' in navigator && window.isSecureContext
+    );
+
+    test.skip(!supportsRegistration, 'Service workers require a secure context.');
+
+    await expect
+      .poll(async () => page.getAttribute('html', 'data-sw-status'))
+      .toBe('registered');
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide basic PWA support so the app can be installed and run in standalone mode with an app shell and icons. 
- Surface a deterministic service-worker registration signal so automated tests can validate runtime wiring. 
- Give non-technical users simple install instructions for iOS/Android and add automated checks to prevent regressions.

### Description

- Add `manifest.webmanifest` with `name`, `short_name`, `start_url`, `scope`, `display: "standalone"`, `theme_color`/`background_color` and a multi-icon set including a `maskable` icon. 
- Add `sw.js` implementing an app-shell caching strategy for `index.html`, `style.css`, and `script.js`, with `CACHE_VERSION` versioning and old-cache cleanup on `activate`. 
- Update `index.html` `<head>` to include `link rel="manifest"`, mobile meta tags (`theme-color`, Apple web app tags), and install-surface icon links (`icon`, `apple-touch-icon`, `mask-icon`). 
- Register the service worker in `script.js` after `DOMContentLoaded` when `'serviceWorker' in navigator`, and set a `data-sw-status` attribute on the `<html>` element to indicate `registered`, `failed`, or `unsupported` for testability. 
- Add user-facing install steps to `README.md` describing how to add the app to Android and iOS home screens. 
- Add Playwright coverage in `tests/pwa.spec.js` that checks for the manifest/icon links and polls the `data-sw-status` signal in secure contexts. 
- Add icon assets under `icons/` used by the manifest and head links.

### Testing

- Ran a quick manifest and service-worker sanity check with `node -e "JSON.parse(fs.readFileSync('manifest.webmanifest'))"` and a simple `sw.js` content check, which both reported OK. 
- Attempted `npm test -- tests/pwa.spec.js` (Playwright) but the browser could not start in this container due to a missing system dependency (`libatk-1.0.so.0`), so the Playwright tests could not complete; `npx playwright install` was also run during validation but runtime launch still failed for the system library. 
- Ran `npm run format` (Prettier check) which reported existing formatting issues across repository files (not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e75993d94832f926f8fc3a998b043)