### PR TITLE
Add local export/import backup (JSON) with validation, UI controls, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ A browser-based checklist that stores steps in localStorage, adds optional mood/
 - **Add a note:** Click **Add note** on a step and type a quick reflection; the note saves immediately.
 - **Keyboard shortcut:** Press Ctrl/Cmd + Enter to add a step when focus isn’t in another text field.
 
+## Backup and restore
+
+Use **Export Journey** and **Import Journey** in the bulk actions row to keep your data portable.
+
+1. Click **Export Journey** to download a `.json` backup file of your steps and settings.
+2. Save the file somewhere safe (cloud drive, external drive, email to yourself, etc.).
+3. On the same or another device, open Journey Log and click **Import Journey**.
+4. Pick your backup file.
+5. If you already have steps, you can choose to **replace** everything with the backup, or **merge** imported steps with current ones.
+
+What gets backed up:
+- Steps (including completion, mood/category/priority, selection state, and notes)
+- Theme selection
+- Wisdom toggle preference
+- Artful mode preference
+
+If the selected file is malformed or not valid Journey Log JSON, the app blocks the import and shows a validation message.
+
+## Optional future sync (integration note)
+
+After local backup/restore is stable, a next step is optional remote sync (for example Supabase or Firebase). A practical phased rollout is:
+
+- Keep local JSON export/import as the source-of-truth fallback.
+- Add authenticated cloud profile storage per user.
+- Sync a normalized task/settings schema identical to local portability format.
+- Resolve conflicts with clear rules (last-write-wins or per-task merge) while preserving manual local import/export.
+
 ## Install on iOS/Android
 
 You can add The Journey Log to your home screen so it opens like an app:

--- a/__tests__/storage-portability.test.js
+++ b/__tests__/storage-portability.test.js
@@ -1,0 +1,80 @@
+const { test, expect } = require('@playwright/test');
+const {
+    createJourneyExport,
+    serializeJourneyExport,
+    parseJourneyImport
+} = require('../src/services/storage');
+
+test.describe('storage portability', () => {
+    test('invalid JSON is rejected', () => {
+        expect(() => parseJourneyImport('{not-valid-json')).toThrow(/Invalid JSON file/);
+    });
+
+    test('successful import preserves key fields', () => {
+        const input = JSON.stringify({
+            tasks: [
+                {
+                    id: 101,
+                    description: ' Plan sprint retrospective ',
+                    completed: true,
+                    selected: false,
+                    mood: 'focused',
+                    category: 'planning',
+                    priority: 'high',
+                    note: 'Bring highlights.'
+                }
+            ],
+            settings: {
+                theme: 'forest',
+                wisdomEnabled: false,
+                artfulMode: true
+            }
+        });
+
+        const imported = parseJourneyImport(input, { createTaskId: () => 9999 });
+
+        expect(imported.tasks).toHaveLength(1);
+        expect(imported.tasks[0]).toEqual({
+            id: 101,
+            description: 'Plan sprint retrospective',
+            completed: true,
+            selected: false,
+            mood: 'focused',
+            category: 'planning',
+            priority: 'high',
+            note: 'Bring highlights.'
+        });
+        expect(imported.settings).toEqual({
+            theme: 'forest',
+            wisdomEnabled: false,
+            artfulMode: true
+        });
+    });
+
+    test('export and import round-trip keeps task and settings integrity', () => {
+        const tasks = [
+            {
+                id: 1,
+                description: 'Write daily reflection',
+                completed: false,
+                selected: true,
+                mood: 'reflective',
+                category: 'creative',
+                priority: 'medium',
+                note: 'Keep it short.'
+            }
+        ];
+        const settings = {
+            theme: 'ocean',
+            wisdomEnabled: true,
+            artfulMode: false
+        };
+
+        const exported = createJourneyExport(tasks, settings);
+        const serialized = serializeJourneyExport(exported);
+        const reImported = parseJourneyImport(serialized, { createTaskId: () => 7777 });
+
+        expect(reImported.tasks).toEqual(tasks);
+        expect(reImported.settings).toEqual(settings);
+    });
+});

--- a/index.html
+++ b/index.html
@@ -170,6 +170,9 @@
             <button id="clearSelectedButton" type="button">Clear selected</button>
             <button id="clearCompletedButton" type="button" aria-label="Clear all completed journey steps">Clear Completed Steps</button>
             <button id="undoDeleteButton" type="button" class="hidden">Undo delete</button>
+            <button id="exportJourneyButton" type="button">Export Journey</button>
+            <button id="importJourneyButton" type="button">Import Journey</button>
+            <input id="importJourneyInput" type="file" accept="application/json,.json" class="hidden" aria-hidden="true" tabindex="-1">
         </div>
 
         <div id="emptyState" class="empty-state hidden" aria-live="polite">

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,4 +1,113 @@
 (function (global) {
+    const PORTABLE_SCHEMA_VERSION = 1;
+
+    function normalizeBoolean(value, fallback = false) {
+        if (typeof value === 'boolean') return value;
+        if (typeof value === 'string') {
+            if (value === 'true') return true;
+            if (value === 'false') return false;
+        }
+        return fallback;
+    }
+
+    function normalizeText(value) {
+        return typeof value === 'string' ? value : '';
+    }
+
+    function normalizeTaskRecord(task, options = {}) {
+        if (!task || typeof task !== 'object' || Array.isArray(task)) return null;
+        const description = normalizeText(task.description).trim();
+        if (!description) return null;
+
+        const fallbackId = options.createTaskId ? options.createTaskId() : Date.now();
+        const normalizedId = Number(task.id);
+        const id = Number.isFinite(normalizedId) ? normalizedId : fallbackId;
+
+        return {
+            id,
+            description,
+            completed: normalizeBoolean(task.completed, false),
+            selected: normalizeBoolean(task.selected, false),
+            mood: normalizeText(task.mood),
+            category: normalizeText(task.category),
+            priority: normalizeText(task.priority),
+            note: normalizeText(task.note)
+        };
+    }
+
+    function buildPortableSettings(settings = {}) {
+        return {
+            theme: normalizeText(settings.theme) || 'comfort',
+            wisdomEnabled: normalizeBoolean(settings.wisdomEnabled, true),
+            artfulMode: normalizeBoolean(settings.artfulMode, false)
+        };
+    }
+
+    function createJourneyExport(tasks = [], settings = {}) {
+        const normalizedTasks = Array.isArray(tasks)
+            ? tasks.map(task => normalizeTaskRecord(task)).filter(Boolean)
+            : [];
+
+        return {
+            schema: 'journey-log',
+            version: PORTABLE_SCHEMA_VERSION,
+            exportedAt: new Date().toISOString(),
+            settings: buildPortableSettings(settings),
+            tasks: normalizedTasks
+        };
+    }
+
+    function serializeJourneyExport(payload) {
+        return JSON.stringify(payload, null, 2);
+    }
+
+    function parseJourneyImport(jsonText, options = {}) {
+        let parsed;
+        try {
+            parsed = JSON.parse(jsonText);
+        } catch (error) {
+            throw new Error('Invalid JSON file. Please choose a valid Journey export.');
+        }
+
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new Error('Import file must contain an object at the top level.');
+        }
+
+        if (parsed.schema && parsed.schema !== 'journey-log') {
+            throw new Error('Import file schema is not supported by Journey Log.');
+        }
+
+        if (parsed.version && Number(parsed.version) > PORTABLE_SCHEMA_VERSION) {
+            throw new Error('Import file version is newer than this app can read.');
+        }
+
+        if (!Array.isArray(parsed.tasks)) {
+            throw new Error('Import file is missing a valid tasks list.');
+        }
+
+        const dedupeIds = new Set();
+        const normalizedTasks = [];
+
+        parsed.tasks.forEach((task) => {
+            const normalized = normalizeTaskRecord(task, options);
+            if (!normalized) return;
+            while (dedupeIds.has(normalized.id)) {
+                normalized.id = options.createTaskId ? options.createTaskId() : (normalized.id + 1);
+            }
+            dedupeIds.add(normalized.id);
+            normalizedTasks.push(normalized);
+        });
+
+        if (normalizedTasks.length === 0 && parsed.tasks.length > 0) {
+            throw new Error('Import file has tasks, but none are valid Journey steps.');
+        }
+
+        return {
+            settings: buildPortableSettings(parsed.settings),
+            tasks: normalizedTasks
+        };
+    }
+
     function createSafeStorage(storage, options = {}) {
         const showPersistenceStatus = options.showPersistenceStatus ?? (() => {});
 
@@ -36,7 +145,14 @@
         };
     }
 
-    const api = { createSafeStorage };
+    const api = {
+        PORTABLE_SCHEMA_VERSION,
+        createSafeStorage,
+        normalizeTaskRecord,
+        createJourneyExport,
+        serializeJourneyExport,
+        parseJourneyImport
+    };
 
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = api;


### PR DESCRIPTION
### Motivation
- Provide a simple, non-technical way for users to back up and restore their Journey data as a portable JSON file. 
- Ensure imported data is safe and normalized to the same shape as existing tasks so the app remains robust against malformed or unexpected input. 
- Surface a clear path to future cloud sync while keeping a reliable local export/import fallback.

### Description
- Added UI controls in the bulk-actions row in `index.html`: `Export Journey`, `Import Journey`, and a hidden file input (`#importJourneyInput`) to trigger import. 
- Implemented portability helpers in `src/services/storage.js`: `normalizeTaskRecord`, `buildPortableSettings`, `createJourneyExport`, `serializeJourneyExport`, and `parseJourneyImport` with schema/version checks, normalization guards, and deduplication of IDs. 
- Wired export/import flows into `src/app/init.js`: `exportJourney` creates and downloads a JSON backup of `state.tasks` + settings, `importJourneyFromText` validates/parses incoming JSON, supports replace-or-merge behavior, applies imported settings (`theme`, `wisdomEnabled`, `artfulMode`), and normalizes records through the existing `normalizeTask` path. 
- Added user-facing validation and error messaging during import and updated `README.md` with a new non-technical `Backup and restore` section and an `Optional future sync` integration note. 
- Added automated tests in `__tests__/storage-portability.test.js` covering invalid JSON rejection, successful import preserving key fields, and export/import round-trip integrity.

### Testing
- Ran the portability unit tests with `npm test -- __tests__/storage-portability.test.js`, and all 3 tests passed successfully. 
- Attempted `npm test -- __tests__/input-validation.test.js`, which failed to launch in this environment because Playwright browser binaries are not installed, not due to application logic. 
- Performed a static check of the app module with `node -c src/app/init.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e84057568832f9ed6647dba2fec0f)