### PR TITLE
Add simple-mode onboarding and progressive reveal for advanced tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,10 @@
             <button id="startCueButton" class="start-cue-cta" type="button">Start with one step</button>
         </section>
 
-        <div class="theme-selector">
+        <button id="advancedToolsToggle" class="advanced-tools-toggle" type="button" aria-expanded="false" aria-controls="advancedToolsPanel">Show more tools</button>
+        <section id="advancedToolsPanel" class="advanced-tools-panel" aria-label="Advanced tools" aria-hidden="true" hidden>
+
+        <div class="theme-selector" data-advanced-control="true">
             <label for="theme">Theme</label>
             <select id="theme">
                 <option value="comfort" selected>Comfort</option>
@@ -57,12 +60,12 @@
             </label>
         </div>
 
-        <div class="wisdom-toggle">
+        <div class="wisdom-toggle" data-advanced-control="true">
             <input type="checkbox" id="wisdomToggle" name="wisdomToggle" checked>
             <label for="wisdomToggle">Show wisdom</label>
         </div>
 
-        <section class="insights" aria-label="Journey insights">
+        <section class="insights" aria-label="Journey insights" data-advanced-control="true">
 
             <div class="insight-card">
 
@@ -103,10 +106,10 @@
             </div>
 
         </section>
-        <p class="insights-caption">Totals show how many steps you have, how many are done, and what remains. The progress bar tracks the percentage completed.</p>
+        <p class="insights-caption" data-advanced-control="true">Totals show how many steps you have, how many are done, and what remains. The progress bar tracks the percentage completed.</p>
 
-        <p class="insights-note">These update when you check or add steps.</p>
-        <div class="milestone-wrapper" aria-live="polite">
+        <p class="insights-note" data-advanced-control="true">These update when you check or add steps.</p>
+        <div class="milestone-wrapper" aria-live="polite" data-advanced-control="true">
             <div class="milestone-header">
                 <p class="milestone-title">Milestones</p>
                 <p class="milestone-subtitle">Unlock markers as you complete steps.</p>
@@ -114,11 +117,14 @@
             <div id="milestoneStrip" class="milestone-strip" aria-label="Milestones" role="group"></div>
         </div>
 
+
+        </section>
+
         <div class="input-section">
 
             <div class="input-meta" aria-label="Journey step details">
                 <input type="text" id="taskInput" placeholder="Add a new step in your journey..." aria-label="New journey step description" autocomplete="off">
-                <div class="selectors">
+                <div class="selectors" data-advanced-control="true">
                     <label for="moodSelect">Mood</label>
                     <select id="moodSelect" aria-label="Select a mood for this step" aria-describedby="moodHelper">
                         <option value="">Mood (optional)</option>
@@ -150,18 +156,18 @@
 
             <div class="cta-wrapper">
                 <button id="addTaskButton" aria-label="Add a new journey step">Add Step</button>
-                <button id="addTaskButtonSecondary" type="button" aria-label="Add a journey step near the keyboard">Add</button>
+                <button id="addTaskButtonSecondary" type="button" aria-label="Add a journey step near the keyboard" data-advanced-control="true">Add</button>
                 <div id="addHelperBubble" class="helper-bubble hidden" role="status" aria-live="polite" aria-hidden="true">
                     Tap Add after you type.
                 </div>
                 <div id="inputValidation" data-testid="input-validation" class="input-validation hidden" role="status" aria-live="polite" aria-hidden="true"></div>
                 <div id="saveStatus" class="save-status" role="status" aria-live="polite" aria-hidden="true"></div>
             </div>
-            <button id="secondaryAddButton" class="secondary-add" type="button" aria-label="Add a journey step (mobile-friendly)">Add</button>
+            <button id="secondaryAddButton" class="secondary-add" type="button" aria-label="Add a journey step (mobile-friendly)" data-advanced-control="true">Add</button>
 
         </div>
 
-        <div class="bulk-actions" role="toolbar" aria-label="Task selection controls">
+        <div class="bulk-actions" role="toolbar" aria-label="Task selection controls" data-advanced-control="true">
             <div class="bulk-toggle">
                 <label class="sr-only" for="selectAllCheckbox">Select all tasks</label>
                 <input type="checkbox" id="selectAllCheckbox" aria-label="Select all tasks">
@@ -192,7 +198,7 @@
 
         </ul>
 
-        <div id="wisdomDisplay" class="hidden" role="region" aria-live="polite" aria-expanded="false">
+        <div id="wisdomDisplay" class="hidden" role="region" aria-live="polite" aria-expanded="false" data-advanced-control="true">
 
             <div class="wisdom-header">
                 <p class="wisdom-title"><strong>Wisdom for this step:</strong></p>

--- a/style.css
+++ b/style.css
@@ -428,6 +428,25 @@ button:focus-visible {
     transform: translateY(-1px);
 }
 
+.advanced-tools-toggle {
+    width: 100%;
+    margin: 4px 0 12px;
+    background-color: var(--panel-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+}
+
+.advanced-tools-panel {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 12px;
+    min-width: 0;
+}
+
+.advanced-tools-panel[hidden] {
+    display: none !important;
+}
+
 .theme-selector label {
     font-weight: 600;
 }
@@ -1002,6 +1021,25 @@ button:focus-visible {
         transform: none;
         width: 100%;
         margin-top: 8px;
+    }
+}
+
+@media (max-width: 375px) {
+    .advanced-tools-toggle {
+        position: sticky;
+        top: 8px;
+        z-index: 3;
+    }
+
+    .advanced-tools-panel {
+        overflow-x: clip;
+    }
+
+    .advanced-tools-panel .theme-selector,
+    .advanced-tools-panel .bulk-actions,
+    .advanced-tools-panel .milestone-strip {
+        min-width: 0;
+        width: 100%;
     }
 }
 

--- a/tests/mobile-layout.spec.js
+++ b/tests/mobile-layout.spec.js
@@ -6,16 +6,16 @@ const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
 test.use({ viewport: { width: 375, height: 700 } });
 
 test.describe('Mobile layout resilience', () => {
-  test('wraps controls and avoids horizontal scroll at 375px', async ({ page }) => {
+  test('keeps simple-mode layout stable and no horizontal scroll at 375px', async ({ page }) => {
     await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
 
     const inputSection = page.locator('.input-section');
     await expect(inputSection).toHaveCSS('flex-direction', 'column');
 
-    const addTaskButton = page.locator('#addTaskButton');
-    const secondaryAddButton = page.locator('#secondaryAddButton');
-    await expect(addTaskButton).toBeVisible();
-    await expect(secondaryAddButton).toBeVisible();
+    await expect(page.locator('#addTaskButton')).toBeVisible();
+    await expect(page.locator('#advancedToolsPanel')).toBeHidden();
 
     const noHorizontalScroll = await page.evaluate(() => {
       const doc = document.documentElement;
@@ -24,28 +24,22 @@ test.describe('Mobile layout resilience', () => {
     expect(noHorizontalScroll).toBeTruthy();
   });
 
-  test('add buttons stay reachable after typing with small viewport', async ({ page }) => {
+  test('no horizontal overflow after progressive reveal on first completion', async ({ page }) => {
     await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
 
-    await page.setViewportSize({ width: 375, height: 550 });
-    const taskInput = page.locator('#taskInput');
-    await taskInput.focus();
-    await taskInput.fill('Testing mobile keyboard space');
+    await page.locator('#taskInput').fill('Mobile reveal task');
+    await page.locator('#addTaskButton').click();
+    await page.locator('[data-testid="complete-checkbox"]').first().check();
 
-    const buttonsInView = await page.evaluate(() => {
-      const withinViewport = (el) => {
-        if (!el) return false;
-        const rect = el.getBoundingClientRect();
-        return rect.top >= 0 && rect.bottom <= window.innerHeight;
-      };
+    await expect(page.locator('#advancedToolsToggle')).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('#advancedToolsPanel')).toBeVisible();
 
-      return {
-        primary: withinViewport(document.getElementById('addTaskButton')),
-        secondary: withinViewport(document.getElementById('secondaryAddButton'))
-      };
+    const noHorizontalScroll = await page.evaluate(() => {
+      const doc = document.documentElement;
+      return doc.scrollWidth <= doc.clientWidth;
     });
-
-    expect(buttonsInView.primary).toBe(true);
-    expect(buttonsInView.secondary).toBe(true);
+    expect(noHorizontalScroll).toBeTruthy();
   });
 });

--- a/tests/onboarding.spec.js
+++ b/tests/onboarding.spec.js
@@ -4,24 +4,46 @@ const { test, expect } = require('@playwright/test');
 const indexFileUrl = `file://${path.join(__dirname, '..', 'index.html')}`;
 
 test.describe('Onboarding cues', () => {
-  test('shows helper bubble on first load and hides after first add', async ({ page }) => {
+  test('shows helper bubble on first load and keeps advanced controls collapsed', async ({ page }) => {
     await page.goto(indexFileUrl);
     await page.evaluate(() => localStorage.clear());
     await page.reload();
 
-    const taskInput = page.locator('#taskInput');
     const addButton = page.getByRole('button', { name: /Add a new journey step/i });
     const helperBubble = page.locator('#addHelperBubble');
+    const advancedToolsToggle = page.locator('#advancedToolsToggle');
+    const advancedToolsPanel = page.locator('#advancedToolsPanel');
 
-    await expect(taskInput).toBeFocused();
+    await expect(addButton).toBeVisible();
     await expect(helperBubble).toBeVisible();
 
-    await taskInput.fill('First guided task');
-    await addButton.click();
+    await expect(advancedToolsToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(advancedToolsPanel).toBeHidden();
+    await expect(page.locator('.theme-selector')).toBeHidden();
+    await expect(page.locator('.bulk-actions')).toHaveAttribute('hidden', '');
+  });
 
-    await expect(helperBubble).toBeHidden();
+  test('reveals advanced tools after first successful task completion', async ({ page }) => {
+    await page.goto(indexFileUrl);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await page.locator('#taskInput').fill('First guided task');
+    await page.getByRole('button', { name: /Add a new journey step/i }).click();
+
+    await expect(page.locator('#addHelperBubble')).toBeHidden();
+
+    const completionCheckbox = page.locator('[data-testid="complete-checkbox"]').first();
+    await completionCheckbox.check();
+
+    const advancedToolsToggle = page.locator('#advancedToolsToggle');
+    const advancedToolsPanel = page.locator('#advancedToolsPanel');
+    await expect(advancedToolsToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(advancedToolsPanel).toBeVisible();
+    await expect(advancedToolsPanel).toHaveAttribute('aria-hidden', 'false');
 
     await page.reload();
-    await expect(helperBubble).toBeHidden();
+    await expect(advancedToolsToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(advancedToolsPanel).toBeVisible();
   });
 });


### PR DESCRIPTION
### Motivation
- Provide a simpler first-run experience that shows only the core input, primary add button, and basic task completion flow while keeping advanced features discoverable but deferred behind an explicit expander.
- Tie the existing `startCueButton` flow to onboarding progression so the app can auto-reveal advanced tools after the user successfully completes their first task.
- Ensure the collapsed/expanded advanced panel behaves and remains accessible on narrow screens (375px) without causing horizontal overflow or layout jumps.

### Description
- Added a new expander toggle and panel (`#advancedToolsToggle`, `#advancedToolsPanel`) and marked advanced blocks with `data-advanced-control="true"` in `index.html` so those controls default to hidden for first-run sessions.
- Implemented onboarding state persistence using `journeyOnboardingStage` with stages `simple | started | complete` and wired state transitions in `src/app/init.js` so `startCueButton` advances onboarding and the app auto-reveals advanced tools after the first completed task; task rendering is adjusted to defer selection/note controls until advanced mode is visible.
- Synced ARIA attributes and visibility (`aria-expanded`, `aria-hidden`, `hidden`) for the expander and advanced controls and gated wisdom rendering behind advanced visibility to preserve accessibility semantics.
- Added responsive styling in `style.css` for the toggle/panel (including a 375px media rule) and ensured collapsed panels use stable layout rules to avoid horizontal overflow and jumping behavior.
- Added/updated Playwright tests `tests/onboarding.spec.js` and `tests/mobile-layout.spec.js` to validate first-run simplified UI, progressive reveal after first completion, ARIA/hidden states, and no horizontal overflow on mobile.

### Testing
- Ran the focused Playwright suite with `npm test -- tests/onboarding.spec.js tests/mobile-layout.spec.js` and all tests passed locally (4 passed).
- Verified a manual headless snapshot of the simple-mode mobile layout (artifact saved during test run).
- Ran `npm run format` which reported unrelated repo-wide Prettier violations; formatting issues are not introduced by this PR and do not affect the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e85a7e37c832f88abc36a3494429e)