### PR TITLE
Add opt-in privacy-preserving analytics with local usage insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,35 @@ A browser-based checklist that stores steps in localStorage, adds optional mood/
 - **Keyboard shortcuts:** Enter adds a step from the input. Ctrl/Cmd + Enter adds a step from elsewhere (except other text inputs). Ctrl/Cmd + Shift + C clears completed steps.
 - **Insights:** Total/active/completed counts and progress bar update from stored steps.
 
+
+## Privacy-first analytics (opt-in)
+
+Journey Log analytics are **disabled by default**. If you opt in via Settings, the app records only a minimal event schema as local aggregate counters in `localStorage`:
+
+- `task_added`
+- `task_completed`
+- `note_used`
+- `theme_changed`
+- `undo_used`
+
+### Data boundaries
+
+- No task description text is collected in analytics.
+- No note body text is collected in analytics.
+- No personally identifying data is added by default.
+- In local-only mode, analytics stay on-device as aggregate counts for self-insight.
+
+### Usage insights panel (dev/optional)
+
+A lightweight **Usage insights (dev)** panel can display local aggregate event counts for feature adoption checks.
+
+- It is intended for local development / inspection.
+- It does not require external analytics services.
+
+### External analytics guardrails (future)
+
+If external analytics is enabled later, only the same sanitized and aggregated metadata should be sent (event type + safe metadata fields). Raw user content (task descriptions, note text) is excluded by design.
+
 ## Technologies
 
 - **HTML** for structure and ARIA-friendly controls.

--- a/__tests__/analytics.test.js
+++ b/__tests__/analytics.test.js
@@ -1,0 +1,72 @@
+const { test, expect } = require('@playwright/test');
+const {
+    ANALYTICS_EVENTS,
+    sanitizeMetadata,
+    createLocalAggregateStore,
+    createEventDispatcher
+} = require('../src/services/analytics');
+
+function createMemoryStorage() {
+    const map = new Map();
+    return {
+        getItem(key) {
+            return map.has(key) ? map.get(key) : null;
+        },
+        setItem(key, value) {
+            map.set(key, String(value));
+        },
+        removeItem(key) {
+            map.delete(key);
+        }
+    };
+}
+
+test.describe('analytics module', () => {
+    test('sanitizes metadata and strips unexpected fields', () => {
+        const sanitized = sanitizeMetadata(ANALYTICS_EVENTS.TASK_ADDED, {
+            hasMood: 1,
+            hasCategory: 'yes',
+            hasPriority: true,
+            description: 'this should never pass through'
+        });
+
+        expect(sanitized).toEqual({
+            hasMood: true,
+            hasCategory: true,
+            hasPriority: true
+        });
+    });
+
+    test('dispatcher no-ops when analytics is disabled', () => {
+        const store = createLocalAggregateStore(createMemoryStorage());
+        const dispatcher = createEventDispatcher({
+            isEnabled: () => false,
+            aggregateStore: store
+        });
+
+        const dispatched = dispatcher.dispatch(ANALYTICS_EVENTS.TASK_COMPLETED, { completed: true });
+
+        expect(dispatched).toBe(false);
+        expect(store.readSnapshot().total).toBe(0);
+    });
+
+    test('dispatcher aggregates counters locally when enabled', () => {
+        const store = createLocalAggregateStore(createMemoryStorage());
+        const dispatcher = createEventDispatcher({
+            isEnabled: () => true,
+            aggregateStore: store
+        });
+
+        dispatcher.dispatch(ANALYTICS_EVENTS.TASK_ADDED, { hasMood: true, hasCategory: false, hasPriority: false });
+        dispatcher.dispatch(ANALYTICS_EVENTS.TASK_ADDED, { hasMood: false, hasCategory: false, hasPriority: false });
+        dispatcher.dispatch(ANALYTICS_EVENTS.THEME_CHANGED, { theme: 'forest', taskText: 'hidden' });
+
+        const snapshot = store.readSnapshot();
+        expect(snapshot.total).toBe(3);
+        expect(snapshot.events[ANALYTICS_EVENTS.TASK_ADDED].count).toBe(2);
+        expect(snapshot.events[ANALYTICS_EVENTS.THEME_CHANGED].count).toBe(1);
+
+        const variants = Object.keys(snapshot.events[ANALYTICS_EVENTS.THEME_CHANGED].variants);
+        expect(variants).toEqual(['{"theme":"forest"}']);
+    });
+});

--- a/__tests__/storage-portability.test.js
+++ b/__tests__/storage-portability.test.js
@@ -27,7 +27,8 @@ test.describe('storage portability', () => {
             settings: {
                 theme: 'forest',
                 wisdomEnabled: false,
-                artfulMode: true
+                artfulMode: true,
+                analyticsOptIn: true
             }
         });
 
@@ -47,7 +48,8 @@ test.describe('storage portability', () => {
         expect(imported.settings).toEqual({
             theme: 'forest',
             wisdomEnabled: false,
-            artfulMode: true
+            artfulMode: true,
+            analyticsOptIn: true
         });
     });
 
@@ -67,7 +69,8 @@ test.describe('storage portability', () => {
         const settings = {
             theme: 'ocean',
             wisdomEnabled: true,
-            artfulMode: false
+            artfulMode: false,
+            analyticsOptIn: false
         };
 
         const exported = createJourneyExport(tasks, settings);

--- a/index.html
+++ b/index.html
@@ -62,6 +62,23 @@
             <label for="wisdomToggle">Show wisdom</label>
         </div>
 
+        <section class="settings-panel" aria-label="Privacy and analytics settings">
+            <p class="settings-title">Settings</p>
+            <label class="settings-toggle" for="analyticsToggle">
+                <input type="checkbox" id="analyticsToggle" name="analyticsToggle">
+                Enable privacy-preserving usage analytics (local-only)
+            </label>
+            <p class="settings-note">Off by default. When enabled, Journey Log stores only event counters on this device and never stores step descriptions or note text in analytics.</p>
+        </section>
+
+        <section id="usageInsightsPanel" class="usage-insights hidden" aria-label="Usage insights" aria-hidden="true">
+            <div class="usage-insights-header">
+                <p class="usage-insights-title">Usage insights (dev)</p>
+                <button id="clearUsageInsightsButton" type="button">Clear insights</button>
+            </div>
+            <pre id="usageInsightsContent" class="usage-insights-content">total_events: 0</pre>
+        </section>
+
         <section class="insights" aria-label="Journey insights">
 
             <div class="insight-card">
@@ -209,6 +226,7 @@
     <script src="src/domain/insights.js"></script>
     <script src="src/domain/tasks.js"></script>
     <script src="src/services/storage.js"></script>
+    <script src="src/services/analytics.js"></script>
     <script src="src/ui/render.js"></script>
     <script src="src/app/init.js"></script>
     <script src="script.js"></script>

--- a/src/app/init.js
+++ b/src/app/init.js
@@ -377,7 +377,7 @@
         updateWisdomVisibility(state.tasks, showWisdom, hideWisdom, { wisdomEnabled });
         taskInput?.focus();
         revealInputSection();
-        applyTheme(safeStorage.get('journeyTheme', defaultTheme));
+        applyTheme(safeStorage.get('journeyTheme', defaultTheme), { trackAnalytics: false });
         syncArtfulMode();
 
         themeSelect?.addEventListener('change', (event) => applyTheme(event.target.value));
@@ -1030,7 +1030,8 @@
             return supportedThemes.includes(theme) ? theme : defaultTheme;
         }
 
-        function applyTheme(themeValue) {
+        function applyTheme(themeValue, options = {}) {
+            const { trackAnalytics = true } = options;
             const normalizedTheme = normalizeTheme(themeValue);
             const previousTheme = bodyElement.dataset.theme || defaultTheme;
             document.documentElement.classList.remove(...themeClasses);
@@ -1071,7 +1072,7 @@
                 themeSelect.value = normalizedTheme;
             }
             safeStorage.set('journeyTheme', normalizedTheme);
-            if (previousTheme !== normalizedTheme) {
+            if (trackAnalytics && previousTheme !== normalizedTheme) {
                 analyticsDispatcher.dispatch(ANALYTICS_EVENTS.THEME_CHANGED, {
                     theme: normalizedTheme
                 });

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -1,0 +1,149 @@
+(function (global) {
+    const ANALYTICS_EVENTS = Object.freeze({
+        TASK_ADDED: 'task_added',
+        TASK_COMPLETED: 'task_completed',
+        NOTE_USED: 'note_used',
+        THEME_CHANGED: 'theme_changed',
+        UNDO_USED: 'undo_used'
+    });
+
+    function sanitizeMetadata(eventName, metadata = {}) {
+        if (!metadata || typeof metadata !== 'object') return {};
+
+        if (eventName === ANALYTICS_EVENTS.TASK_ADDED) {
+            return {
+                hasMood: Boolean(metadata.hasMood),
+                hasCategory: Boolean(metadata.hasCategory),
+                hasPriority: Boolean(metadata.hasPriority)
+            };
+        }
+
+        if (eventName === ANALYTICS_EVENTS.TASK_COMPLETED) {
+            return {
+                completed: Boolean(metadata.completed)
+            };
+        }
+
+        if (eventName === ANALYTICS_EVENTS.NOTE_USED) {
+            return {
+                action: metadata.action === 'cleared' ? 'cleared' : 'added'
+            };
+        }
+
+        if (eventName === ANALYTICS_EVENTS.THEME_CHANGED) {
+            return {
+                theme: typeof metadata.theme === 'string' ? metadata.theme : 'unknown'
+            };
+        }
+
+        if (eventName === ANALYTICS_EVENTS.UNDO_USED) {
+            return {
+                restoredCount: Number.isFinite(Number(metadata.restoredCount)) ? Number(metadata.restoredCount) : 0
+            };
+        }
+
+        return {};
+    }
+
+    function createLocalAggregateStore(storage, options = {}) {
+        const storageKey = options.storageKey || 'journeyAnalyticsAggregate';
+
+        function readSnapshot() {
+            try {
+                const raw = storage.getItem(storageKey);
+                if (!raw) return { total: 0, events: {} };
+                const parsed = JSON.parse(raw);
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    return { total: 0, events: {} };
+                }
+                const events = parsed.events && typeof parsed.events === 'object' && !Array.isArray(parsed.events)
+                    ? parsed.events
+                    : {};
+                return {
+                    total: Number(parsed.total) || 0,
+                    events
+                };
+            } catch (error) {
+                console.warn('Analytics aggregate could not be read from storage.', error);
+                return { total: 0, events: {} };
+            }
+        }
+
+        function writeSnapshot(snapshot) {
+            try {
+                storage.setItem(storageKey, JSON.stringify(snapshot));
+                return true;
+            } catch (error) {
+                console.warn('Analytics aggregate could not be saved to storage.', error);
+                return false;
+            }
+        }
+
+        function increment(eventName, metadata = {}) {
+            const snapshot = readSnapshot();
+            const eventBucket = snapshot.events[eventName] || { count: 0, variants: {} };
+            eventBucket.count += 1;
+            const variantKey = JSON.stringify(metadata);
+            eventBucket.variants[variantKey] = (eventBucket.variants[variantKey] || 0) + 1;
+            snapshot.events[eventName] = eventBucket;
+            snapshot.total += 1;
+            writeSnapshot(snapshot);
+            return snapshot;
+        }
+
+        function clear() {
+            writeSnapshot({ total: 0, events: {} });
+        }
+
+        return {
+            readSnapshot,
+            increment,
+            clear
+        };
+    }
+
+    function createEventDispatcher(options = {}) {
+        const isEnabled = options.isEnabled ?? (() => false);
+        const aggregateStore = options.aggregateStore;
+        const externalSink = options.externalSink ?? null;
+
+        function dispatch(eventName, metadata = {}) {
+            if (!Object.values(ANALYTICS_EVENTS).includes(eventName)) {
+                return false;
+            }
+            if (!isEnabled()) {
+                return false;
+            }
+
+            const safeMetadata = sanitizeMetadata(eventName, metadata);
+            aggregateStore?.increment(eventName, safeMetadata);
+
+            if (typeof externalSink === 'function') {
+                externalSink({
+                    event: eventName,
+                    timestamp: new Date().toISOString(),
+                    metadata: safeMetadata
+                });
+            }
+
+            return true;
+        }
+
+        return {
+            dispatch
+        };
+    }
+
+    const api = {
+        ANALYTICS_EVENTS,
+        sanitizeMetadata,
+        createLocalAggregateStore,
+        createEventDispatcher
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+
+    global.JourneyLogAnalytics = api;
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -39,7 +39,8 @@
         return {
             theme: normalizeText(settings.theme) || 'comfort',
             wisdomEnabled: normalizeBoolean(settings.wisdomEnabled, true),
-            artfulMode: normalizeBoolean(settings.artfulMode, false)
+            artfulMode: normalizeBoolean(settings.artfulMode, false),
+            analyticsOptIn: normalizeBoolean(settings.analyticsOptIn, false)
         };
     }
 

--- a/style.css
+++ b/style.css
@@ -448,6 +448,65 @@ button:focus-visible {
     color: var(--muted-text);
 }
 
+.wisdom-toggle {
+    margin-bottom: 12px;
+}
+
+.settings-panel,
+.usage-insights {
+    background: linear-gradient(145deg, var(--surface-color), var(--panel-color));
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 12px 14px;
+    margin-bottom: 14px;
+}
+
+.settings-title,
+.usage-insights-title {
+    margin: 0 0 8px;
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+.settings-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.settings-note {
+    margin: 8px 0 0;
+    color: var(--muted-text);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.usage-insights-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.usage-insights-header button {
+    padding: 8px 10px;
+    font-size: 14px;
+}
+
+.usage-insights-content {
+    margin: 6px 0 0;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 10px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    font-size: 13px;
+    white-space: pre-wrap;
+}
+
+
 .insights {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));


### PR DESCRIPTION
### Motivation

- Provide a privacy-first, opt-in analytics path that never collects task or note text while allowing local feature-adoption insight. 
- Offer developers and users a local-only aggregate view for self-inspection and small-scale adoption checks without external services. 
- Prepare a safe, sanitized pipeline for any future external analytics by restricting payloads to aggregated metadata only.

### Description

- Introduced a new analytics service module `src/services/analytics.js` implementing a minimal event schema (`task_added`, `task_completed`, `note_used`, `theme_changed`, `undo_used`), metadata sanitization, a local aggregate store, and a dispatcher that no-ops when opt-in is disabled. 
- Added a user-facing opt-in toggle in `index.html` (default off) plus a small dev-only "Usage insights" panel to read/clear aggregated event counters, and included basic styling in `style.css`. 
- Wired analytics dispatches into app flows in `src/app/init.js` for task add/complete, note add/clear, theme changes, and undo actions, and updated export/import snapshots to persist `analyticsOptIn` via `src/services/storage.js`. 
- Added unit tests for the analytics module and updated portability tests: `__tests__/analytics.test.js` and `__tests__/storage-portability.test.js`.

### Testing

- Ran `npm test -- __tests__/analytics.test.js __tests__/storage-portability.test.js` and all tests passed (6 passed).
- The analytics unit tests verify metadata sanitization, dispatcher no-op behavior when disabled, and local aggregation when enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e85b2d25c832fa9e381ce7fc847b6)